### PR TITLE
feat: add reusable route/comment cards and improve RouteFormDialog

### DIFF
--- a/app/components/ReviewFormDialog.vue
+++ b/app/components/ReviewFormDialog.vue
@@ -36,7 +36,8 @@
                 <!-- Context row: shown only in edit mode -->
                 <div
                     v-if="isEditMode && review"
-                    class="d-flex align-center ga-3 mb-5 pa-3 rounded-lg bg-surface-variant"
+                    class="d-flex align-center ga-3 mb-5 pa-3 rounded-lg"
+                    style="background: rgba(var(--v-theme-on-surface), 0.06)"
                 >
                     <v-avatar size="30" :color="avatarColor(review.userName)">
                         <span

--- a/app/components/RouteFormDialog.vue
+++ b/app/components/RouteFormDialog.vue
@@ -9,6 +9,7 @@
             <v-divider />
             <v-card-text class="pa-4">
                 <v-form ref="formRef" @submit.prevent="submit">
+                    <!-- Name -->
                     <v-text-field
                         v-model="form.name"
                         :label="$t('routes.name')"
@@ -20,30 +21,18 @@
                         class="mb-1"
                     />
 
+                    <!-- Difficulty and Type -->
                     <v-row density="comfortable" class="mb-1">
                         <v-col cols="6">
                             <v-select
-                                v-model="form.difficulty"
+                                v-model="form.combinedDifficulty"
                                 :label="$t('climbing.difficulty')"
-                                :items="difficulties"
+                                :items="combinedDifficulties"
                                 :rules="[requiredRule]"
                                 required
                                 density="comfortable"
                             />
                         </v-col>
-                        <v-col cols="6">
-                            <v-select
-                                v-model="form.difficulty_sign"
-                                :label="$t('climbing.difficulty_sign')"
-                                :items="difficultySignItems"
-                                item-title="title"
-                                item-value="value"
-                                density="comfortable"
-                            />
-                        </v-col>
-                    </v-row>
-
-                    <v-row density="comfortable" class="mb-1">
                         <v-col cols="6">
                             <v-select
                                 v-model="form.type"
@@ -52,6 +41,23 @@
                                 item-title="title"
                                 item-value="value"
                                 :rules="[requiredRule]"
+                                required
+                                density="comfortable"
+                            />
+                        </v-col>
+                    </v-row>
+
+                    <!-- Anchor Point and Location -->
+                    <v-row density="comfortable" class="mb-1">
+                        <v-col cols="6">
+                            <v-text-field
+                                v-model.number="form.anchor_point"
+                                :label="$t('climbing.anchor_point')"
+                                :rules="anchorPointRules"
+                                type="number"
+                                :min="isBoulderRoute ? 0 : 1"
+                                max="100"
+                                step="1"
                                 required
                                 density="comfortable"
                             />
@@ -68,19 +74,7 @@
                         </v-col>
                     </v-row>
 
-                    <v-text-field
-                        v-model.number="form.anchor_point"
-                        :label="$t('climbing.anchor_point')"
-                        :rules="anchorPointRules"
-                        type="number"
-                        :min="isBoulderRoute ? 0 : 1"
-                        max="100"
-                        step="1"
-                        required
-                        density="comfortable"
-                        class="mb-1"
-                    />
-
+                    <!-- Route Setter -->
                     <v-combobox
                         v-model="form.creator"
                         :label="$t('routes.route_setter')"
@@ -94,16 +88,30 @@
                         class="mb-1"
                     />
 
-                    <v-text-field
-                        v-model="form.screw_date"
-                        :label="$t('routes.screwed_at')"
-                        type="date"
-                        :rules="[requiredRule]"
-                        required
-                        density="comfortable"
-                        class="mb-1"
-                    />
+                    <!-- Screwed at and Archived -->
+                    <v-row density="comfortable" class="mb-1">
+                        <v-col cols="6">
+                            <v-text-field
+                                v-model="form.screw_date"
+                                :label="$t('routes.screwed_at')"
+                                type="date"
+                                :rules="[requiredRule]"
+                                required
+                                density="comfortable"
+                            />
+                        </v-col>
+                        <v-col v-if="isEditMode" cols="6" style="align-self: stretch; display: flex; align-items: center; justify-content: center;">
+                            <v-switch
+                                v-model="form.archived"
+                                :label="$t('climbing.archived')"
+                                color="primary"
+                                density="compact"
+                                hide-details
+                            />
+                        </v-col>
+                    </v-row>
 
+                    <!-- Comment -->
                     <v-textarea
                         v-model="form.comment"
                         :label="$t('climbing.comment')"
@@ -114,16 +122,7 @@
                         class="mb-2"
                     />
 
-                    <v-switch
-                        v-if="isEditMode"
-                        v-model="form.archived"
-                        :label="$t('climbing.archived')"
-                        :true-value="true"
-                        :false-value="false"
-                        density="comfortable"
-                        class="mb-2"
-                    />
-
+                    <!-- Color picker -->
                     <div class="color-picker-section">
                         <v-color-picker
                             v-model="form.color"
@@ -140,6 +139,15 @@
             </v-card-text>
             <v-divider />
             <v-card-actions class="pa-3">
+                <v-btn
+                    v-if="isEditMode"
+                    color="error"
+                    variant="text"
+                    prepend-icon="mdi-delete-outline"
+                    @click="deleteDialog = true"
+                >
+                    {{ $t('actions.delete') }}
+                </v-btn>
                 <v-spacer />
                 <v-btn variant="text" @click="close">{{
                     $t('actions.cancel')
@@ -155,6 +163,14 @@
             </v-card-actions>
         </v-card>
     </v-dialog>
+
+    <ConfirmDialog
+        v-model="deleteDialog"
+        :title="$t('actions.confirm')"
+        :message="$t('notifications.deleteItem')"
+        :loading="deleting"
+        @confirm="deleteRoute"
+    />
 </template>
 
 <script setup lang="ts">
@@ -170,7 +186,6 @@ type VFormHandle = {
     validate: () => Promise<{ valid: boolean }>
     reset: () => void
 } | null
-type DifficultySignInternal = '' | '+' | '-'
 
 const colorSwatches = [
     ['#F44336', '#FF9800', '#FFC107'], // red, orange, yellow
@@ -183,6 +198,8 @@ const colorSwatches = [
 
 const dialogOpen = ref(false)
 const saving = ref(false)
+const deleting = ref(false)
+const deleteDialog = ref(false)
 const formRef = ref<VFormHandle>(null)
 const setterItems = ref<string[]>([])
 const editRouteId = ref<string | null>(null)
@@ -190,8 +207,7 @@ const originalAnchorPointIsZero = ref(false)
 
 const form = reactive({
     name: '',
-    difficulty: '',
-    difficulty_sign: '' as DifficultySignInternal,
+    combinedDifficulty: null as string | null,
     anchor_point: null as number | null,
     location: '',
     type: '',
@@ -205,14 +221,12 @@ const form = reactive({
 const isEditMode = computed(() => editRouteId.value !== null)
 const isBoulderRoute = computed(() => form.type === 'Boulder')
 
-const difficulties = Array.from({ length: 10 }, (_, i) => String(i + 1))
 const locations = ['Hanau', 'Gelnhausen']
 
-const difficultySignItems = [
-    { title: '—', value: '' },
-    { title: '+', value: '+' },
-    { title: '-', value: '-' },
-]
+const combinedDifficulties = Array.from({ length: 10 }, (_, i) => {
+    const d = i + 1
+    return [`${d} -`, String(d), `${d} +`]
+}).flat()
 
 const typeItems = computed(() => [
     { title: t('routes.types.route'), value: 'Route' },
@@ -246,18 +260,31 @@ const anchorPointRules = [
 const creatorRule = (v: string[]) =>
     (Array.isArray(v) && v.length > 0) || t('validation.required')
 
-const toDifficultySignInternal = (
-    raw: RouteRecord['difficulty_sign'],
-): DifficultySignInternal => {
-    if (raw === true || raw === '+') return '+'
-    if (raw === false || raw === '-') return '-'
-    return ''
+const toCombinedDifficulty = (
+    difficulty: RouteRecord['difficulty'],
+    sign: RouteRecord['difficulty_sign'],
+): string | null => {
+    if (difficulty === null || difficulty === undefined) return null
+    const d = String(difficulty)
+    if (sign === true || sign === '+') return `${d} +`
+    if (sign === false || sign === '-') return `${d} -`
+    return d
+}
+
+const parseCombinedDifficulty = (
+    combined: string | null,
+): { difficulty: number | null; difficulty_sign: boolean | null } => {
+    if (!combined) return { difficulty: null, difficulty_sign: null }
+    if (combined.endsWith(' +'))
+        return { difficulty: Number(combined.slice(0, -2)), difficulty_sign: true }
+    if (combined.endsWith(' -'))
+        return { difficulty: Number(combined.slice(0, -2)), difficulty_sign: false }
+    return { difficulty: Number(combined), difficulty_sign: null }
 }
 
 const resetForm = () => {
     form.name = ''
-    form.difficulty = ''
-    form.difficulty_sign = ''
+    form.combinedDifficulty = null
     form.anchor_point = null
     form.location = ''
     form.type = ''
@@ -275,8 +302,7 @@ const loadFromRoute = (route: RouteRecord) => {
     originalAnchorPointIsZero.value = Number(route.anchor_point) === 0
 
     form.name = route.name ?? ''
-    form.difficulty = String(route.difficulty ?? '')
-    form.difficulty_sign = toDifficultySignInternal(route.difficulty_sign)
+    form.combinedDifficulty = toCombinedDifficulty(route.difficulty, route.difficulty_sign)
     form.anchor_point = route.anchor_point ?? null
     form.location = route.location ?? ''
     form.type = route.type ?? ''
@@ -315,6 +341,7 @@ function close() {
 const emit = defineEmits<{
     saved: [payload: Partial<RouteRecord>]
     closed: []
+    deleted: [id: string]
 }>()
 
 watch(dialogOpen, (val) => {
@@ -328,17 +355,12 @@ async function submit() {
 
     saving.value = true
     try {
-        const signValue =
-            form.difficulty_sign === '+'
-                ? true
-                : form.difficulty_sign === '-'
-                  ? false
-                  : null
+        const { difficulty, difficulty_sign } = parseCombinedDifficulty(form.combinedDifficulty)
 
         const payload: Partial<RouteRecord> = {
             name: form.name,
-            difficulty: Number(form.difficulty),
-            difficulty_sign: signValue,
+            difficulty: difficulty ?? undefined,
+            difficulty_sign,
             anchor_point: form.anchor_point,
             location: form.location,
             type: form.type,
@@ -361,6 +383,22 @@ async function submit() {
         console.error('Failed to save route:', error)
     } finally {
         saving.value = false
+    }
+}
+
+async function deleteRoute() {
+    if (!editRouteId.value) return
+    deleting.value = true
+    try {
+        await pb.collection('routes').delete(editRouteId.value)
+        const id = editRouteId.value
+        deleteDialog.value = false
+        close()
+        emit('deleted', id)
+    } catch (error) {
+        console.error('Failed to delete route:', error)
+    } finally {
+        deleting.value = false
     }
 }
 

--- a/app/components/comments/Card.vue
+++ b/app/components/comments/Card.vue
@@ -1,0 +1,349 @@
+<template>
+    <v-card variant="tonal" class="comment-card">
+        <!-- Header: [checkbox?] avatar · name + date · star rating -->
+        <div class="comment-card__header">
+            <v-checkbox
+                v-if="selectable"
+                :model-value="selected"
+                color="primary"
+                hide-details
+                density="compact"
+                class="comment-card__checkbox"
+                @update:modelValue="$emit('toggle-select')"
+            />
+            <v-avatar
+                size="32"
+                :color="comment.userAvatar ? undefined : avatarColor(comment.userName)"
+                class="flex-shrink-0"
+            >
+                <v-img
+                    v-if="comment.userAvatar"
+                    :src="comment.userAvatar"
+                    cover
+                />
+                <span v-else class="text-caption font-weight-bold text-white">
+                    {{ initials(comment.userName) }}
+                </span>
+            </v-avatar>
+
+            <div class="comment-card__title">
+                <span class="comment-card__name">{{ comment.userName }}</span>
+                <span class="comment-card__date">{{ formattedDate }}</span>
+            </div>
+
+            <v-rating
+                v-if="comment.rating != null"
+                :model-value="comment.rating"
+                readonly
+                density="compact"
+                active-color="yellow-darken-2"
+                color="grey-lighten-2"
+                class="flex-shrink-0 comment-card__rating"
+            />
+        </div>
+
+        <v-divider />
+
+        <!-- Meta section -->
+        <div class="comment-card__meta">
+            <!-- Comment text -->
+            <div
+                v-if="comment.comment"
+                class="comment-card__meta-row comment-card__meta-row--full"
+            >
+                <v-icon size="15" class="comment-card__meta-icon"
+                    >mdi-comment-text-outline</v-icon
+                >
+                <div class="comment-card__comment-wrap">
+                    <span
+                        class="comment-card__comment"
+                        :class="{ 'comment-card__comment--collapsed': collapsible && !expanded && isLong }"
+                    >{{ comment.comment }}</span>
+                    <v-btn
+                        v-if="collapsible && isLong"
+                        variant="text"
+                        density="compact"
+                        size="x-small"
+                        :color="expanded ? 'default' : 'primary'"
+                        class="mt-1 px-0 text-none d-block"
+                        @click="expanded = !expanded"
+                    >
+                        {{ expanded ? t('comments.showLess') : t('comments.showMore') }}
+                    </v-btn>
+                </div>
+            </div>
+
+            <!-- Route row (admin view) -->
+            <div
+                v-if="showRoute && comment.routeName"
+                class="comment-card__meta-row comment-card__meta-row--full"
+            >
+                <v-icon size="15" class="comment-card__meta-icon"
+                    >mdi-routes</v-icon
+                >
+                <NuxtLink
+                    v-if="comment.routeId"
+                    :to="`/route?id=${comment.routeId}`"
+                    class="comment-card__route-link text-body-2 font-weight-medium text-primary text-decoration-none"
+                >
+                    {{ comment.routeName }}
+                </NuxtLink>
+                <span v-else class="text-body-2 font-weight-medium">{{ comment.routeName }}</span>
+            </div>
+
+            <!-- Pills: location · difficulty -->
+            <div class="comment-card__pills">
+                <span v-if="comment.location" class="comment-card__pill">
+                    <v-icon size="13">mdi-map-marker</v-icon>
+                    {{ comment.location }}
+                </span>
+                <v-tooltip v-if="comment.difficultyLabel" location="top" :text="t('ratings.perceived_difficulty')">
+                    <template #activator="{ props: tooltipProps }">
+                        <span v-bind="tooltipProps" class="comment-card__pill comment-card__pill--primary">
+                            <v-icon size="13">mdi-gauge</v-icon>
+                            {{ t('ratings.felt') }} {{ comment.difficultyLabel }}
+                        </span>
+                    </template>
+                </v-tooltip>
+            </div>
+        </div>
+
+        <v-card-actions v-if="$slots.actions" class="comment-card__actions">
+            <v-spacer />
+            <slot name="actions" />
+        </v-card-actions>
+    </v-card>
+</template>
+
+<script setup lang="ts">
+export interface CommentCardItem {
+    id: string
+    userName: string
+    userAvatar?: string | null
+    rating?: number | null
+    created: string
+    comment?: string | null
+    difficultyLabel?: string | null
+    routeName?: string | null
+    routeId?: string | null
+    location?: string | null
+}
+
+const props = withDefaults(
+    defineProps<{
+        comment: CommentCardItem
+        selectable?: boolean
+        selected?: boolean
+        showRoute?: boolean
+        dateFormat?: 'relative' | 'absolute'
+        collapsible?: boolean
+    }>(),
+    {
+        selectable: false,
+        selected: false,
+        showRoute: false,
+        dateFormat: 'absolute',
+        collapsible: true,
+    },
+)
+
+defineEmits<{
+    (e: 'toggle-select'): void
+}>()
+
+const { t, locale } = useI18n()
+
+// ── Collapse ────────────────────────────────────────────────────────────────
+
+const expanded = ref(false)
+const LONG_THRESHOLD = 200
+const isLong = computed(
+    () =>
+        typeof props.comment.comment === 'string' &&
+        props.comment.comment.length > LONG_THRESHOLD,
+)
+
+// ── Date ────────────────────────────────────────────────────────────────────
+
+const formattedDate = computed(() => {
+    const d = props.comment.created
+    if (!d) return '—'
+    if (props.dateFormat === 'relative') return timeAgo(d)
+    return new Date(d).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+    })
+})
+
+function timeAgo(dateStr: string): string {
+    const diff = Date.now() - new Date(dateStr).getTime()
+    const mins = Math.floor(diff / 60_000)
+    const hours = Math.floor(diff / 3_600_000)
+    const days = Math.floor(diff / 86_400_000)
+    if (mins < 1) return t('time.justNow')
+    if (mins < 60) return t('time.minutesAgo', { n: mins })
+    if (hours < 24) return t('time.hoursAgo', { n: hours })
+    if (days < 30) return t('time.daysAgo', { n: days })
+    return new Date(dateStr).toLocaleDateString(locale.value, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+    })
+}
+
+// ── Avatar ──────────────────────────────────────────────────────────────────
+
+const AVATAR_COLORS = [
+    'primary',
+    'secondary',
+    'success',
+    'info',
+    'deep-purple',
+    'teal',
+    'indigo',
+    'pink',
+    'cyan',
+    'orange',
+]
+
+function avatarColor(name: string): string {
+    if (!name) return 'primary'
+    const code = [...name].reduce((acc, ch) => acc + ch.charCodeAt(0), 0)
+    return AVATAR_COLORS[code % AVATAR_COLORS.length]
+}
+
+function initials(name: string): string {
+    if (!name) return '?'
+    return name
+        .split(' ')
+        .slice(0, 2)
+        .map((n) => n[0]?.toUpperCase() ?? '')
+        .join('')
+}
+</script>
+
+<style scoped>
+.comment-card {
+    position: relative;
+    overflow: hidden;
+}
+
+.comment-card__header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 16px;
+}
+
+.comment-card__checkbox {
+    margin: 0;
+    padding: 0;
+    flex-shrink: 0;
+}
+
+.comment-card__title {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.comment-card__name {
+    font-weight: 600;
+    font-size: 1rem;
+    line-height: 1.3;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.comment-card__date {
+    font-size: 0.75rem;
+    color: rgba(var(--v-theme-on-surface), 0.55);
+    line-height: 1.2;
+}
+
+/* Meta block */
+.comment-card__meta {
+    padding: 10px 16px 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.comment-card__meta-row {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+}
+
+.comment-card__meta-row--full {
+    width: 100%;
+}
+
+.comment-card__meta-icon {
+    flex-shrink: 0;
+    opacity: 0.65;
+    margin-top: 3px;
+}
+
+.comment-card__comment-wrap {
+    flex: 1;
+    min-width: 0;
+}
+
+.comment-card__comment {
+    font-size: 0.8rem;
+    color: rgba(var(--v-theme-on-surface), 0.7);
+    white-space: pre-wrap;
+    word-break: break-word;
+    line-height: 1.5;
+}
+
+.comment-card__comment--collapsed {
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.comment-card__route-link:hover {
+    text-decoration: underline !important;
+}
+
+/* Inline pill row */
+.comment-card__pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 2px;
+}
+
+.comment-card__pill :deep(.v-icon) {
+    margin-top: 1px;
+}
+
+.comment-card__pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.75rem;
+    color: rgba(var(--v-theme-on-surface), 0.7);
+    background: rgba(var(--v-theme-on-surface), 0.06);
+    border-radius: 6px;
+    padding: 3px 8px;
+}
+
+.comment-card__pill--primary {
+    color: rgb(var(--v-theme-primary));
+    background: rgba(var(--v-theme-primary), 0.08);
+}
+
+
+.comment-card__actions {
+    padding: 6px 10px 8px;
+    min-height: unset;
+}
+</style>

--- a/app/components/notifications/newVersionAvailable.vue
+++ b/app/components/notifications/newVersionAvailable.vue
@@ -1,6 +1,6 @@
 <template>
-    <v-container>
-        <v-row justify="center" v-if="newVersionAvailable">
+    <v-container v-if="newVersionAvailable">
+        <v-row justify="center">
             <v-col cols="auto">
                 <v-alert type="info" dense>
                     {{ $t('notifications.newVersionAvailable') }}

--- a/app/components/route/Card.vue
+++ b/app/components/route/Card.vue
@@ -1,0 +1,274 @@
+<template>
+    <v-card variant="tonal" class="route-card">
+        <!-- Header: [checkbox?] avatar · name + badges · difficulty -->
+        <div class="route-card__header">
+            <v-checkbox
+                v-if="selectable"
+                :model-value="modelValue"
+                color="primary"
+                hide-details
+                density="compact"
+                class="route-card__checkbox"
+                @update:modelValue="$emit('update:modelValue', $event)"
+            />
+            <v-avatar
+                :color="route.color ?? undefined"
+                size="32"
+                class="flex-shrink-0"
+            />
+            <div class="route-card__title">
+                <span class="route-card__name">{{ route.name }}</span>
+                <span
+                    v-if="route.has_ratings || route.archived"
+                    class="route-card__badges"
+                >
+                    <v-icon
+                        v-if="route.has_ratings"
+                        color="yellow-darken-2"
+                        size="14"
+                        >mdi-star-circle</v-icon
+                    >
+                    <v-chip
+                        v-if="route.archived"
+                        size="x-small"
+                        variant="outlined"
+                        class="ml-1"
+                        >{{ $t('filter.archived') }}</v-chip
+                    >
+                </span>
+            </div>
+            <div v-if="difficulty" class="route-card__difficulty">
+                <span>{{ difficultySplit.base }}</span
+                ><span v-if="difficultySplit.sign" class="route-card__difficulty-sign">{{ difficultySplit.sign }}</span>
+            </div>
+        </div>
+
+        <v-divider />
+
+        <!-- Compact meta section -->
+        <div class="route-card__meta">
+            <!-- Comment -->
+            <div
+                v-if="route.comment"
+                class="route-card__meta-row route-card__meta-row--full"
+            >
+                <v-icon size="15" class="route-card__meta-icon"
+                    >mdi-comment-text-outline</v-icon
+                >
+                <span class="route-card__comment">{{ route.comment }}</span>
+            </div>
+
+            <!-- Creators -->
+            <div
+                v-if="route.creator?.length"
+                class="route-card__meta-row route-card__meta-row--full"
+            >
+                <v-icon size="15" class="route-card__meta-icon"
+                    >mdi-account-hard-hat</v-icon
+                >
+                <div class="d-flex flex-wrap" style="gap: 4px 4px;">
+                    <v-chip
+                        v-for="c in route.creator"
+                        :key="c"
+                        size="x-small"
+                        class="ma-0"
+                        >{{ c }}</v-chip
+                    >
+                </div>
+            </div>
+
+            <!-- Inline pills: anchor · date · location · type · score -->
+            <div class="route-card__pills">
+                <span v-if="anchorPoint !== '—'" class="route-card__pill">
+                    {{ $t('climbing.anchor_point') }} {{ anchorPoint }}
+                </span>
+                <span v-if="screwDate" class="route-card__pill">
+                    <v-icon size="13">mdi-calendar-month</v-icon>
+                    {{ screwDate }}
+                </span>
+                <span v-if="route.location" class="route-card__pill">
+                    <v-icon size="13">mdi-map-marker</v-icon>
+                    {{ route.location }}
+                </span>
+                <span v-if="route.type" class="route-card__pill">
+                    <v-icon size="13">mdi-shape</v-icon>
+                    {{ route.type }}
+                </span>
+                <span v-if="hasScore" class="route-card__pill">
+                    <v-icon size="13">mdi-star</v-icon>
+                    {{ score }}
+                </span>
+            </div>
+        </div>
+
+        <v-card-actions v-if="$slots.actions" class="route-card__actions">
+            <v-spacer />
+            <slot name="actions" />
+        </v-card-actions>
+    </v-card>
+</template>
+
+<script setup lang="ts">
+import type { RouteListItem } from '~/types/models'
+import {
+    formatDifficulty,
+    formatAnchorPoint,
+    formatScore,
+} from '~/utils/formatting'
+
+const props = withDefaults(
+    defineProps<{
+        route: RouteListItem
+        selectable?: boolean
+        modelValue?: boolean
+    }>(),
+    {
+        selectable: false,
+        modelValue: false,
+    },
+)
+
+defineEmits<{
+    (e: 'update:modelValue', value: boolean): void
+}>()
+
+const { locale } = useI18n()
+
+const difficulty = computed(() => formatDifficulty(props.route))
+const difficultySplit = computed(() => {
+    const full = difficulty.value
+    const match = full.match(/^(.*?)([+\-]?)$/)
+    return { base: match?.[1] ?? full, sign: match?.[2] ?? '' }
+})
+const anchorPoint = computed(() =>
+    String(formatAnchorPoint(props.route.anchor_point)),
+)
+const screwDate = computed(() => {
+    const d = props.route.screw_date
+    if (!d) return ''
+    try {
+        return new Date(d).toLocaleDateString(locale.value ?? undefined)
+    } catch {
+        return ''
+    }
+})
+const hasScore = computed(
+    () =>
+        typeof props.route.score === 'number' &&
+        Number.isFinite(props.route.score),
+)
+const score = computed(() => formatScore(props.route))
+</script>
+
+<style scoped>
+.route-card {
+    position: relative;
+    overflow: hidden;
+}
+
+.route-card__header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 16px;
+}
+
+.route-card__difficulty {
+    margin-left: auto;
+    font-size: 1.4rem;
+    font-weight: 700;
+    line-height: 1;
+    color: rgba(var(--v-theme-on-surface), 0.55);
+    flex-shrink: 0;
+}
+
+.route-card__difficulty-sign {
+    margin-left: 3px;
+}
+
+.route-card__checkbox {
+    margin: 0;
+    padding: 0;
+    flex-shrink: 0;
+}
+
+.route-card__title {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.route-card__name {
+    font-weight: 600;
+    font-size: 1rem;
+    line-height: 1.3;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.route-card__badges {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+/* Meta block */
+.route-card__meta {
+    padding: 10px 16px 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.route-card__meta-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 7px;
+}
+
+.route-card__meta-row--full {
+    width: 100%;
+}
+
+.route-card__meta-icon {
+    flex-shrink: 0;
+    margin-top: 2px;
+    opacity: 0.65;
+}
+
+.route-card__comment {
+    font-size: 0.8rem;
+    color: rgba(var(--v-theme-on-surface), 0.7);
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+
+/* Inline pill row */
+.route-card__pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 2px;
+}
+
+.route-card__pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.75rem;
+    color: rgba(var(--v-theme-on-surface), 0.7);
+    background: rgba(var(--v-theme-on-surface), 0.06);
+    border-radius: 6px;
+    padding: 3px 8px;
+}
+
+.route-card__actions {
+    padding: 6px 10px 8px;
+    min-height: unset;
+}
+</style>

--- a/app/components/user/UserIcon.vue
+++ b/app/components/user/UserIcon.vue
@@ -25,7 +25,7 @@
         </template>
 
         <v-card rounded="xl" elevation="3" border>
-            <v-list density="compact" nav class="py-2">
+            <v-list density="compact" :lines="false" nav slim class="py-1">
                 <v-list-item
                     v-for="item in menuItems"
                     :key="item.key"
@@ -33,6 +33,7 @@
                     :title="item.title"
                     :base-color="item.color"
                     :disabled="item.disabled"
+                    density="compact"
                     rounded="lg"
                     @click="handleAction(item)"
                 />

--- a/app/pages/admin/comments.vue
+++ b/app/pages/admin/comments.vue
@@ -1,8 +1,8 @@
 <template>
     <v-container fluid class="comments-page">
         <!-- ── Page Header + inline stats ────────────────────────────────── -->
-        <div class="d-flex align-center justify-space-between mb-3">
-            <h1 class="text-h5 font-weight-bold">{{ t('routes.comments') }}</h1>
+        <div class="d-flex align-center justify-space-between mb-4">
+            <h1 class="comments-page__title">{{ t('routes.comments') }}</h1>
         </div>
 
         <!-- Stats: horizontal scroll on mobile, row on desktop -->
@@ -247,171 +247,14 @@
                 sm="6"
                 lg="4"
             >
-                <v-card
-                    rounded="xl"
-                    border
-                    flat
-                    class="comment-card d-flex flex-column"
-                    :class="{
-                        'comment-card--selected': selectedMap[comment.id],
-                    }"
+                <CommentsCard
+                    :comment="comment"
+                    selectable
+                    :selected="!!selectedMap[comment.id]"
+                    show-route
+                    @toggle-select="toggleSelect(comment.id)"
                 >
-                    <!-- Header: avatar + user + date + star rating -->
-                    <v-card-item class="pb-1 pt-3">
-                        <template #prepend>
-                            <v-avatar
-                                size="38"
-                                :color="
-                                    selectedMap[comment.id]
-                                        ? 'primary'
-                                        : comment.userAvatar
-                                          ? undefined
-                                          : avatarColor(comment.userName)
-                                "
-                                class="select-avatar"
-                                :title="
-                                    t(
-                                        selectedMap[comment.id]
-                                            ? 'comments.deselect'
-                                            : 'comments.select',
-                                    )
-                                "
-                                @click="toggleSelect(comment.id)"
-                            >
-                                <v-icon
-                                    v-if="selectedMap[comment.id]"
-                                    color="white"
-                                    size="20"
-                                    >mdi-check</v-icon
-                                >
-                                <v-img
-                                    v-else-if="comment.userAvatar"
-                                    :src="comment.userAvatar"
-                                    cover
-                                />
-                                <span
-                                    v-else
-                                    class="text-caption font-weight-bold text-white"
-                                >
-                                    {{ initials(comment.userName) }}
-                                </span>
-                            </v-avatar>
-                        </template>
-
-                        <v-card-title
-                            class="text-body-2 font-weight-semibold px-0 py-0"
-                            style="line-height: 1.3"
-                        >
-                            {{ comment.userName }}
-                        </v-card-title>
-                        <v-card-subtitle
-                            class="text-caption px-0 py-0"
-                            style="opacity: 0.7"
-                        >
-                            {{ formatDate(comment.created) }}
-                        </v-card-subtitle>
-
-                        <template #append>
-                            <v-rating
-                                :model-value="comment.rating"
-                                readonly
-                                density="compact"
-                                size="small"
-                                active-color="yellow-darken-2"
-                                color="grey-lighten-2"
-                            />
-                        </template>
-                    </v-card-item>
-
-                    <!-- Route name + location + difficulty chips -->
-                    <div class="px-4 pb-2 d-flex flex-wrap align-center ga-1">
-                        <NuxtLink
-                            :to="`/route?id=${comment.expand?.route_id?.id}`"
-                            class="text-body-2 font-weight-medium text-primary text-decoration-none route-link"
-                        >
-                            <v-icon size="13" class="mb-1 mr-1"
-                                >mdi-routes</v-icon
-                            >{{ comment.routeName }}
-                        </NuxtLink>
-                        <v-chip
-                            v-if="comment.location"
-                            size="x-small"
-                            variant="tonal"
-                            class="ml-1"
-                        >
-                            {{ comment.location }}
-                        </v-chip>
-                        <v-chip
-                            v-if="comment.difficulty != null"
-                            size="x-small"
-                            color="primary"
-                            variant="tonal"
-                        >
-                            {{ formatDifficulty(comment) }}
-                        </v-chip>
-                    </div>
-
-                    <v-divider class="mx-4" />
-
-                    <!-- Comment body (collapsible) -->
-                    <v-card-text class="py-3 flex-grow-1">
-                        <p
-                            class="text-body-2 comment-text mb-0"
-                            :class="{
-                                'comment-collapsed': !expandedIds.has(
-                                    comment.id,
-                                ),
-                            }"
-                        >
-                            {{ comment.comment }}
-                        </p>
-                        <v-btn
-                            v-if="isLong(comment.comment)"
-                            variant="text"
-                            density="compact"
-                            size="x-small"
-                            :color="
-                                expandedIds.has(comment.id)
-                                    ? 'default'
-                                    : 'primary'
-                            "
-                            class="mt-1 px-0 text-none"
-                            @click="toggleExpand(comment.id)"
-                        >
-                            {{
-                                expandedIds.has(comment.id)
-                                    ? t('comments.showLess')
-                                    : t('comments.showMore')
-                            }}
-                        </v-btn>
-                    </v-card-text>
-
-                    <!-- Actions -->
-                    <v-card-actions class="pt-0 px-2 pb-2">
-                        <v-btn
-                            size="small"
-                            variant="text"
-                            density="compact"
-                            class="text-none"
-                            :color="
-                                selectedMap[comment.id] ? 'primary' : 'default'
-                            "
-                            :prepend-icon="
-                                selectedMap[comment.id]
-                                    ? 'mdi-check-circle'
-                                    : 'mdi-circle-outline'
-                            "
-                            @click="toggleSelect(comment.id)"
-                        >
-                            {{
-                                t(
-                                    selectedMap[comment.id]
-                                        ? 'comments.deselect'
-                                        : 'comments.select',
-                                )
-                            }}
-                        </v-btn>
-                        <v-spacer />
+                    <template #actions>
                         <v-btn
                             icon
                             size="small"
@@ -427,8 +270,8 @@
                             :commentId="comment.id"
                             @comment-deleted="onCommentDeleted(comment.id)"
                         />
-                    </v-card-actions>
-                </v-card>
+                    </template>
+                </CommentsCard>
             </v-col>
         </v-row>
 
@@ -513,9 +356,6 @@ const selectedDifficulty = ref(null)
 const selectedRating = ref(0) // 0 = sentinel for "all ratings"
 const dateFilter = ref('')
 const sortOrder = ref('newest')
-
-// Expanded set (recreated on mutation to stay reactive)
-const expandedIds = ref(new Set())
 
 // Selection: reactive object { [id]: true } — Vue tracks per-key access,
 // so toggling one ID only re-renders that one card instead of all of them.
@@ -632,8 +472,10 @@ function buildSort() {
 function mapComment(c) {
     return {
         ...c,
+        routeId: c.expand?.route_id?.id ?? null,
         routeName: c.expand?.route_id?.name ?? 'N/A',
         location: c.expand?.route_id?.location ?? null,
+        difficultyLabel: c.difficulty != null ? formatDifficulty(c) : null,
         userName:
             c.expand?.user?.name ||
             c.expand?.user?.username ||
@@ -777,60 +619,6 @@ function clearSelection() {
     Object.keys(selectedMap).forEach((k) => delete selectedMap[k])
 }
 
-// ── Expand/collapse helpers ────────────────────────────────────────────────
-
-const LONG_THRESHOLD = 200
-
-function isLong(text) {
-    return typeof text === 'string' && text.length > LONG_THRESHOLD
-}
-
-function toggleExpand(id) {
-    const next = new Set(expandedIds.value)
-    if (next.has(id)) next.delete(id)
-    else next.add(id)
-    expandedIds.value = next
-}
-
-// ── Display helpers ────────────────────────────────────────────────────────
-
-function initials(name) {
-    if (!name) return '?'
-    return name
-        .split(' ')
-        .slice(0, 2)
-        .map((n) => n[0]?.toUpperCase() ?? '')
-        .join('')
-}
-
-const AVATAR_COLORS = [
-    'primary',
-    'secondary',
-    'success',
-    'info',
-    'deep-purple',
-    'teal',
-    'indigo',
-    'pink',
-    'cyan',
-    'orange',
-]
-
-function avatarColor(name) {
-    if (!name) return 'primary'
-    const code = [...name].reduce((acc, ch) => acc + ch.charCodeAt(0), 0)
-    return AVATAR_COLORS[code % AVATAR_COLORS.length]
-}
-
-function formatDate(date) {
-    if (!date) return '—'
-    return new Date(date).toLocaleDateString(undefined, {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-    })
-}
-
 // ── Lifecycle ──────────────────────────────────────────────────────────────
 
 const { subscribe } = usePbSubscription()
@@ -885,6 +673,13 @@ onMounted(async () => {
     max-width: 100%;
 }
 
+.comments-page__title {
+    font-size: 1.6rem;
+    font-weight: 700;
+    letter-spacing: -0.3px;
+    color: rgb(var(--v-theme-on-background));
+}
+
 /* ── Stats horizontal scroll ─────────────────────────────────────────── */
 .stats-scroll {
     overflow-x: auto;
@@ -911,49 +706,6 @@ onMounted(async () => {
         flex: 1 1 0;
         min-width: 0;
     }
-}
-
-/* Card selection highlight */
-.comment-card {
-    transition:
-        border-color 0.15s ease,
-        box-shadow 0.15s ease;
-}
-
-.comment-card--selected {
-    border-color: rgb(var(--v-theme-primary)) !important;
-    box-shadow: 0 0 0 2px rgba(var(--v-theme-primary), 0.18) !important;
-}
-
-/* Avatar turns into a toggle button */
-.select-avatar {
-    cursor: pointer;
-    transition:
-        background-color 0.15s ease,
-        opacity 0.15s ease;
-}
-
-.select-avatar:hover {
-    opacity: 0.85;
-}
-
-/* Route name link */
-.route-link:hover {
-    text-decoration: underline !important;
-}
-
-/* Comment text: collapsed = 4 lines max */
-.comment-text {
-    white-space: pre-wrap;
-    word-break: break-word;
-    line-height: 1.5;
-}
-
-.comment-collapsed {
-    display: -webkit-box;
-    -webkit-line-clamp: 4;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
 }
 
 /* Bulk action bar that slides in at the bottom of the filter card */

--- a/app/pages/admin/routes.vue
+++ b/app/pages/admin/routes.vue
@@ -2,32 +2,38 @@
     <v-container fluid class="route-manager">
         <NotificationsNewVersionAvailable />
 
-        <v-row align="start" class="mb-2">
-            <v-col>
-                <h1>{{ $t('routes.dashboard') }}</h1>
-            </v-col>
-            <v-col cols="auto" class="d-flex pt-3 ga-2">
-                <v-btn
-                    color="primary"
-                    variant="tonal"
-                    prepend-icon="mdi-routes"
-                    @click="routeFormRef.open()"
-                >
-                    {{ $t('climbing.create') }}
-                </v-btn>
-
-                <v-btn
-                    color="primary"
-                    variant="tonal"
-                    prepend-icon="mdi-file-import-outline"
-                    @click="importRouteRef.open()"
-                >
-                    {{ $t('actions.import') }}
-                </v-btn>
+        <v-row class="mb-4">
+            <v-col
+                cols="12"
+                class="d-flex flex-column flex-sm-row align-sm-center justify-space-between gap-4"
+            >
+                <h1 class="route-manager__page-title">
+                    {{ $t('routes.dashboard') }}
+                </h1>
+                <div class="d-flex align-center ga-2">
+                    <v-btn
+                        color="primary"
+                        variant="tonal"
+                        rounded="lg"
+                        prepend-icon="mdi-routes"
+                        @click="routeFormRef.open()"
+                    >
+                        {{ $t('climbing.create') }}
+                    </v-btn>
+                    <v-btn
+                        color="primary"
+                        variant="tonal"
+                        rounded="lg"
+                        prepend-icon="mdi-file-import-outline"
+                        @click="importRouteRef.open()"
+                    >
+                        {{ $t('actions.import') }}
+                    </v-btn>
+                </div>
             </v-col>
         </v-row>
 
-        <RouteFormDialog ref="routeFormRef" @saved="reloadRoutes" />
+        <RouteFormDialog ref="routeFormRef" @saved="reloadRoutes" @deleted="reloadRoutes" />
         <ImportRoute ref="importRouteRef" @closed="reloadRoutes" />
 
         <v-row>
@@ -223,10 +229,8 @@
                                 v-for="creator in item.creator"
                                 :key="creator"
                                 size="small"
-                                class="route-manager__creator-chip"
-                            >
-                                {{ creator }}
-                            </v-chip>
+                                class="ma-0"
+                            >{{ creator }}</v-chip>
                         </div>
                     </template>
                     <template #item.score="{ item }">
@@ -271,185 +275,25 @@
                             :key="route.id"
                             cols="12"
                         >
-                            <v-card
-                                variant="outlined"
-                                class="route-manager__mobile-card"
+                            <RouteCard
+                                :route="route"
+                                selectable
+                                :model-value="route.selected"
+                                @update:model-value="
+                                    updateRouteSelection(route, $event)
+                                "
                             >
-                                <div class="route-manager__mobile-difficulty">
-                                    {{ formatDifficulty(route) }}
-                                </div>
-                                <div class="route-manager__mobile-header">
-                                    <v-checkbox
-                                        :model-value="route.selected"
-                                        color="primary"
-                                        hide-details
-                                        density="compact"
-                                        @update:modelValue="
-                                            updateRouteSelection(route, $event)
-                                        "
-                                    />
-                                    <v-avatar
-                                        :color="route.color"
-                                        size="32"
-                                        class="mr-3"
-                                    />
-                                    <div class="route-manager__mobile-name">
-                                        <span
-                                            class="route-manager__mobile-name-text"
-                                            >{{ route.name }}</span
-                                        >
-                                        <div
-                                            class="route-manager__mobile-name-meta"
-                                        >
-                                            <v-icon
-                                                v-if="route.has_ratings"
-                                                color="yellow-darken-2"
-                                                size="small"
-                                            >
-                                                mdi-star-circle
-                                            </v-icon>
-                                            <v-chip
-                                                v-if="route.archived"
-                                                size="x-small"
-                                                variant="outlined"
-                                                class="ml-2"
-                                            >
-                                                {{ $t('filter.archived') }}
-                                            </v-chip>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <v-divider class="my-2" />
-
-                                <v-list density="compact" class="py-0">
-                                    <v-list-item
-                                        :subtitle="route.comment || '—'"
-                                    >
-                                        <template #prepend>
-                                            <v-icon size="small" class="mr-3"
-                                                >mdi-comment-text-outline</v-icon
-                                            >
-                                        </template>
-                                    </v-list-item>
-
-                                    <v-list-item>
-                                        <template #prepend>
-                                            <v-icon size="small" class="mr-3"
-                                                >mdi-account-hard-hat</v-icon
-                                            >
-                                        </template>
-                                        <div
-                                            class="route-manager__mobile-creators"
-                                        >
-                                            <v-chip
-                                                v-for="creator in route.creator"
-                                                :key="creator"
-                                                size="x-small"
-                                            >
-                                                {{ creator }}
-                                            </v-chip>
-                                        </div>
-                                    </v-list-item>
-
-                                    <v-list-item>
-                                        <template #prepend>
-                                            <v-icon size="small" class="mr-3"
-                                                >mdi-map-marker</v-icon
-                                            >
-                                        </template>
-                                        <v-list-item-title
-                                            class="text-caption text-uppercase"
-                                        >
-                                            {{ $t('climbing.location') }}
-                                        </v-list-item-title>
-                                        <v-list-item-subtitle>{{
-                                            route.location || '—'
-                                        }}</v-list-item-subtitle>
-                                    </v-list-item>
-
-                                    <v-list-item>
-                                        <template #prepend>
-                                            <v-icon size="small" class="mr-3"
-                                                >mdi-shape</v-icon
-                                            >
-                                        </template>
-                                        <v-list-item-title
-                                            class="text-caption text-uppercase"
-                                        >
-                                            {{ $t('climbing.type') }}
-                                        </v-list-item-title>
-                                        <v-list-item-subtitle>{{
-                                            route.type || '—'
-                                        }}</v-list-item-subtitle>
-                                    </v-list-item>
-
-                                    <v-list-item>
-                                        <template #prepend>
-                                            <v-icon size="small" class="mr-3"
-                                                >mdi-pound</v-icon
-                                            >
-                                        </template>
-                                        <v-list-item-title
-                                            class="text-caption text-uppercase"
-                                        >
-                                            {{ $t('climbing.anchor_point') }}
-                                        </v-list-item-title>
-                                        <v-list-item-subtitle>{{
-                                            formatAnchorPoint(
-                                                route.anchor_point,
-                                            )
-                                        }}</v-list-item-subtitle>
-                                    </v-list-item>
-
-                                    <v-list-item>
-                                        <template #prepend>
-                                            <v-icon size="small" class="mr-3"
-                                                >mdi-star</v-icon
-                                            >
-                                        </template>
-                                        <v-list-item-title
-                                            class="text-caption text-uppercase"
-                                        >
-                                            {{ $t('ratings.score') }}
-                                        </v-list-item-title>
-                                        <v-list-item-subtitle>{{
-                                            formatScore(route)
-                                        }}</v-list-item-subtitle>
-                                    </v-list-item>
-
-                                    <v-list-item>
-                                        <template #prepend>
-                                            <v-icon size="small" class="mr-3"
-                                                >mdi-calendar-month</v-icon
-                                            >
-                                        </template>
-                                        <v-list-item-title
-                                            class="text-caption text-uppercase"
-                                        >
-                                            {{ $t('routes.screwed_at') }}
-                                        </v-list-item-title>
-                                        <v-list-item-subtitle>{{
-                                            formatDate(route.screw_date)
-                                        }}</v-list-item-subtitle>
-                                    </v-list-item>
-                                </v-list>
-
-                                <v-card-actions
-                                    class="pa-2 route-manager__mobile-actions"
-                                >
-                                    <v-spacer />
+                                <template #actions>
+                                    <RouteDetails :route_id="route.id" />
                                     <v-btn
                                         icon
                                         size="small"
-                                        class="mr-1"
                                         @click="routeFormRef.open(route)"
                                     >
                                         <v-icon>mdi-pencil</v-icon>
                                     </v-btn>
-                                    <RouteDetails :route_id="route.id" />
-                                </v-card-actions>
-                            </v-card>
+                                </template>
+                            </RouteCard>
                         </v-col>
                     </v-row>
 
@@ -980,6 +824,13 @@ useHead(() => ({
     padding-bottom: 64px;
 }
 
+.route-manager__page-title {
+    font-size: 1.6rem;
+    font-weight: 700;
+    letter-spacing: -0.3px;
+    color: rgb(var(--v-theme-on-background));
+}
+
 .route-manager__actions {
     display: flex;
     flex-wrap: wrap;
@@ -1015,12 +866,6 @@ useHead(() => ({
     gap: 4px;
 }
 
-.route-manager__creator-chip {
-    max-width: 120px;
-    text-overflow: ellipsis;
-    overflow: hidden;
-}
-
 .route-manager__row-actions {
     display: flex;
     gap: 4px;
@@ -1031,55 +876,6 @@ useHead(() => ({
     display: flex;
     flex-direction: column;
     gap: 16px;
-}
-
-.route-manager__mobile-card {
-    position: relative;
-    overflow: hidden;
-}
-
-.route-manager__mobile-difficulty {
-    position: absolute;
-    top: 8px;
-    right: 12px;
-    font-weight: 600;
-    color: rgba(var(--v-theme-on-surface), 0.6);
-}
-
-.route-manager__mobile-header {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 16px 16px 8px;
-}
-
-.route-manager__mobile-name {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-}
-
-.route-manager__mobile-name-text {
-    font-weight: 600;
-    line-height: 1.25;
-}
-
-.route-manager__mobile-name-meta {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-}
-
-.route-manager__mobile-creators {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
-}
-
-.route-manager__mobile-actions {
-    justify-content: flex-end;
-    gap: 8px;
 }
 
 .route-manager__mobile-empty {

--- a/app/pages/admin/users.vue
+++ b/app/pages/admin/users.vue
@@ -1,8 +1,8 @@
 <template>
     <v-container fluid class="users-page">
         <!-- ── Page Header ───────────────────────────────────────────────── -->
-        <div class="d-flex align-center justify-space-between mb-3">
-            <h1 class="text-h5 font-weight-bold">{{ t('users.title') }}</h1>
+        <div class="d-flex align-center justify-space-between mb-4">
+            <h1 class="users-page__title">{{ t('users.title') }}</h1>
             <UserCreateUser @user-created="reloadUsers" />
         </div>
 
@@ -466,6 +466,13 @@ onMounted(async () => {
 <style scoped>
 .users-page {
     max-width: 100%;
+}
+
+.users-page__title {
+    font-size: 1.6rem;
+    font-weight: 700;
+    letter-spacing: -0.3px;
+    color: rgb(var(--v-theme-on-background));
 }
 
 .user-card {

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -100,8 +100,8 @@
                                 v-for="c in item.creator"
                                 :key="c"
                                 size="small"
-                                >{{ c }}</v-chip
-                            >
+                                class="ma-0"
+                            >{{ c }}</v-chip>
                         </div>
                     </template>
                     <template #item.screw_date="{ item }">
@@ -120,113 +120,23 @@
                             :key="route.id"
                             cols="12"
                         >
-                            <v-card
-                                variant="outlined"
-                                class="mobile-route-card"
-                            >
-                                <div
-                                    class="route-difficulty-display text-h5 font-weight-bold"
-                                >
-                                    {{ formatDifficulty(route) }}
-                                </div>
-                                <v-list-item class="pt-3 pb-2 pr-12">
-                                    <template #prepend>
-                                        <v-avatar
-                                            :color="route.color"
-                                            size="32"
-                                            class="mr-4"
-                                        />
-                                    </template>
-                                    <v-list-item-title
-                                        class="text-h6 font-weight-bold d-flex align-center"
-                                    >
-                                        {{ route.name }}
-                                        <v-icon
-                                            v-if="route.has_ratings"
-                                            color="yellow-darken-2"
-                                            size="small"
-                                            class="ml-2"
-                                            >mdi-star-circle</v-icon
-                                        >
-                                    </v-list-item-title>
-                                </v-list-item>
-                                <v-divider />
-                                <v-list density="compact" class="py-1">
-                                    <v-list-item
-                                        :subtitle="route.comment || '—'"
-                                    >
-                                        <template #prepend
-                                            ><v-icon size="small" class="mr-3"
-                                                >mdi-comment-text-outline</v-icon
-                                            ></template
-                                        >
-                                    </v-list-item>
-                                    <v-list-item>
-                                        <template #prepend
-                                            ><v-icon size="small" class="mr-3"
-                                                >mdi-account-hard-hat</v-icon
-                                            ></template
-                                        >
-                                        <div class="d-flex ga-1 flex-wrap mt-1">
-                                            <v-chip
-                                                v-for="c in route.creator"
-                                                :key="c"
-                                                size="x-small"
-                                                >{{ c }}</v-chip
-                                            >
-                                        </div>
-                                    </v-list-item>
-                                    <v-list-item>
-                                        <template #prepend
-                                            ><v-icon size="small" class="mr-3"
-                                                >mdi-pound</v-icon
-                                            ></template
-                                        >
-                                        <v-list-item-title
-                                            class="text-caption text-uppercase"
-                                            >{{
-                                                $t('climbing.anchor_point')
-                                            }}</v-list-item-title
-                                        >
-                                        <v-list-item-subtitle>{{
-                                            formatAnchorPoint(
-                                                route.anchor_point,
-                                            )
-                                        }}</v-list-item-subtitle>
-                                    </v-list-item>
-                                    <v-list-item
-                                        :subtitle="
-                                            formatDate(route.screw_date) || '—'
-                                        "
-                                    >
-                                        <template #prepend
-                                            ><v-icon size="small" class="mr-3"
-                                                >mdi-calendar-month</v-icon
-                                            ></template
-                                        >
-                                    </v-list-item>
-                                </v-list>
-                                <v-card-actions class="pa-2">
-                                    <v-spacer />
+                            <RouteCard :route="route">
+                                <template #actions>
                                     <RouteDetails :route_id="route.id" />
-                                </v-card-actions>
-                            </v-card>
+                                </template>
+                            </RouteCard>
                         </v-col>
                     </v-row>
 
-                    <!-- "Load More" Button for Mobile -->
-                    <div
-                        v-if="routes.length < totalItems"
-                        class="text-center pa-4"
-                    >
-                        <v-btn
-                            :loading="loading"
-                            @click="loadMore"
-                            variant="tonal"
+                    <!-- Infinite scroll sentinel -->
+                    <div ref="sentinelRef" class="pa-4 text-center">
+                        <v-progress-circular
+                            v-if="loading && routes.length > 0"
+                            indeterminate
+                            size="24"
+                            width="2"
                             color="primary"
-                        >
-                            {{ $t('actions.load_more') }}
-                        </v-btn>
+                        />
                     </div>
                 </div>
 
@@ -251,7 +161,7 @@
 
 <script setup lang="ts">
 import type PocketBase from 'pocketbase'
-import type { RatingRecord, RouteListItem, RouteRecord } from '~/types/models'
+import type { AverageRatingRecord, RouteListItem, RouteRecord } from '~/types/models'
 import {
     formatDifficulty,
     formatAnchorPoint,
@@ -308,6 +218,7 @@ const tableOptions = reactive<TableOptions>({
 const loading = ref(true)
 const routes = ref<RouteListItem[]>([])
 const totalItems = ref(0)
+const sentinelRef = useTemplateRef<HTMLElement>('sentinelRef')
 
 const headersDesktop: Array<{
     title: string
@@ -358,33 +269,34 @@ async function loadRoutes(
             )
 
         const routeIds = res.items.map((route) => route.id)
-        let ratedRouteIds = new Set<string>()
+        let averageMap = new Map<string, number | null>()
 
         if (routeIds.length > 0) {
-            const ratingsFilter = routeIds
-                .map((id) => `route_id = "${id}"`)
-                .join(' || ')
-            const ratingsRecords = await pb
-                .collection('ratings')
-                .getFullList<RatingRecord>({
-                    filter: ratingsFilter,
-                    fields: 'route_id',
-                })
-
-            const ids = ratingsRecords
-                .map((rating) => rating.route_id)
-                .filter(
-                    (routeId): routeId is string =>
-                        typeof routeId === 'string' && routeId.length > 0,
+            try {
+                const filter = routeIds.map((id) => `id = "${id}"`).join(' || ')
+                const avgRecords = await pb
+                    .collection('averageRating')
+                    .getFullList<AverageRatingRecord>({
+                        filter,
+                        fields: 'id,average_rating',
+                    })
+                averageMap = new Map(
+                    avgRecords.map((r) => [r.id, r.average_rating ?? null]),
                 )
-            ratedRouteIds = new Set(ids)
+            } catch {
+                // ratings are optional — don't block route display
+            }
         }
 
-        const newRoutes: RouteListItem[] = res.items.map((route) => ({
-            ...route,
-            creator: normalizeCreators(route.creator),
-            has_ratings: ratedRouteIds.has(route.id),
-        }))
+        const newRoutes: RouteListItem[] = res.items.map((route) => {
+            const avg = averageMap.get(route.id)
+            return {
+                ...route,
+                creator: normalizeCreators(route.creator),
+                has_ratings: typeof avg === 'number' && !Number.isNaN(avg),
+                score: typeof avg === 'number' ? avg : undefined,
+            }
+        })
 
         if (meta.append) {
             routes.value = routes.value.concat(newRoutes)
@@ -401,8 +313,22 @@ async function loadRoutes(
 }
 
 function loadMore() {
+    if (loading.value || routes.value.length >= totalItems.value) return
     tableOptions.page += 1
     void loadRoutes({}, { append: true })
+}
+
+let scrollObserver: IntersectionObserver | null = null
+
+function setupScrollObserver() {
+    if (!sentinelRef.value) return
+    scrollObserver = new IntersectionObserver(
+        (entries) => {
+            if (entries[0]?.isIntersecting) loadMore()
+        },
+        { rootMargin: '200px' },
+    )
+    scrollObserver.observe(sentinelRef.value)
 }
 
 let debounceT: ReturnType<typeof setTimeout> | null = null
@@ -427,6 +353,7 @@ onMounted(async () => {
             void loadRoutes({}, { append: false })
         }),
     ])
+    setupScrollObserver()
 })
 
 onBeforeUnmount(() => {
@@ -434,12 +361,14 @@ onBeforeUnmount(() => {
         clearTimeout(debounceT)
         debounceT = null
     }
+    scrollObserver?.disconnect()
 })
 
 function formatDate(date: string | null | undefined) {
     if (!date) return ''
-    return new Date(date).toLocaleDateString('de-DE')
+    return new Date(date).toLocaleDateString()
 }
+
 </script>
 
 <style scoped>
@@ -457,21 +386,8 @@ function formatDate(date: string | null | undefined) {
     white-space: nowrap;
 }
 .creator-chips {
-    max-height: 40px;
-    overflow: hidden;
     display: flex;
-    gap: 4px;
     flex-wrap: wrap;
-}
-.mobile-route-card {
-    position: relative;
-    overflow: hidden;
-}
-.route-difficulty-display {
-    position: absolute;
-    top: 8px;
-    right: 12px;
-    z-index: 1;
-    color: rgba(var(--v-theme-on-surface), 0.6);
+    gap: 4px;
 }
 </style>

--- a/app/pages/route.vue
+++ b/app/pages/route.vue
@@ -215,88 +215,13 @@
 
                 <!-- Review list -->
                 <template v-if="reviews.length">
-                    <v-card
-                        v-for="(review, idx) in reviews"
+                    <CommentsCard
+                        v-for="review in reviews"
                         :key="review.id"
-                        rounded="xl"
-                        border
-                        flat
-                        :class="[
-                            'review-card',
-                            'mb-3',
-                            { 'review-card--first': idx === 0 },
-                        ]"
-                    >
-                        <div class="pa-4">
-                            <!-- Header: avatar + name + time -->
-                            <div class="d-flex align-center mb-3">
-                                <v-avatar
-                                    size="40"
-                                    :color="
-                                        review.userAvatar
-                                            ? undefined
-                                            : avatarColor(review.userName)
-                                    "
-                                    class="mr-3"
-                                >
-                                    <v-img
-                                        v-if="review.userAvatar"
-                                        :src="review.userAvatar"
-                                        cover
-                                    />
-                                    <span
-                                        v-else
-                                        class="text-caption font-weight-bold text-white"
-                                    >
-                                        {{ initials(review.userName) }}
-                                    </span>
-                                </v-avatar>
-                                <div class="flex-grow-1">
-                                    <div
-                                        class="text-body-2 font-weight-semibold"
-                                    >
-                                        {{ review.userName }}
-                                    </div>
-                                    <div
-                                        class="text-caption text-medium-emphasis"
-                                    >
-                                        {{ timeAgo(review.created) }}
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- Rating + difficulty row -->
-                            <div class="d-flex align-center ga-3 mb-2">
-                                <v-rating
-                                    v-if="review.rating"
-                                    :model-value="review.rating"
-                                    readonly
-                                    density="compact"
-                                    size="18"
-                                    active-color="yellow-darken-2"
-                                    color="grey-lighten-2"
-                                />
-                                <v-chip
-                                    v-if="review.difficulty"
-                                    size="x-small"
-                                    color="primary"
-                                    variant="tonal"
-                                    class="font-weight-bold"
-                                >
-                                    {{ review.difficulty }}
-                                </v-chip>
-                            </div>
-
-                            <!-- Comment -->
-                            <p
-                                v-if="review.comment"
-                                class="text-body-2 mb-0"
-                                style="line-height: 1.5"
-                            >
-                                {{ review.comment }}
-                            </p>
-                        </div>
-                    </v-card>
+                        :comment="review"
+                        date-format="relative"
+                        class="mb-3"
+                    />
                 </template>
 
                 <!-- Empty state -->
@@ -346,7 +271,7 @@ const metadata = ref<RouteListItem | null>(null)
 interface ReviewDisplay {
     id: string
     rating: number | null
-    difficulty: string
+    difficultyLabel: string
     comment: string | null
     created: string
     userName: string
@@ -409,11 +334,11 @@ const avgRating = computed(() => {
 })
 
 const avgPerceivedDifficulty = computed(() => {
-    const withDiff = reviews.value.filter((r) => r.difficulty)
+    const withDiff = reviews.value.filter((r) => r.difficultyLabel)
     if (!withDiff.length) return null
     const counts: Record<string, number> = {}
     withDiff.forEach((r) => {
-        counts[r.difficulty] = (counts[r.difficulty] ?? 0) + 1
+        counts[r.difficultyLabel] = (counts[r.difficultyLabel] ?? 0) + 1
     })
     return Object.entries(counts).sort((a, b) => b[1] - a[1])[0][0]
 })
@@ -473,7 +398,7 @@ function mapReview(
     return {
         id: r.id,
         rating: typeof r.rating === 'number' ? r.rating : null,
-        difficulty: formatDifficulty(r),
+        difficultyLabel: formatDifficulty(r),
         comment: r.comment ?? null,
         created: r.created ?? '',
         userName,
@@ -483,53 +408,6 @@ function mapReview(
 
 function onReviewSaved() {
     void getAllRouteRatings()
-}
-
-// ── Display helpers ────────────────────────────────────────────────────────
-
-const AVATAR_COLORS = [
-    'primary',
-    'secondary',
-    'success',
-    'info',
-    'deep-purple',
-    'teal',
-    'indigo',
-    'pink',
-    'cyan',
-    'orange',
-]
-
-function avatarColor(name: string): string {
-    if (!name) return 'primary'
-    const code = [...name].reduce((acc, ch) => acc + ch.charCodeAt(0), 0)
-    return AVATAR_COLORS[code % AVATAR_COLORS.length]
-}
-
-function initials(name: string): string {
-    if (!name) return '?'
-    return name
-        .split(' ')
-        .slice(0, 2)
-        .map((n) => n[0]?.toUpperCase() ?? '')
-        .join('')
-}
-
-function timeAgo(dateStr: string): string {
-    if (!dateStr) return ''
-    const diff = Date.now() - new Date(dateStr).getTime()
-    const mins = Math.floor(diff / 60_000)
-    const hours = Math.floor(diff / 3_600_000)
-    const days = Math.floor(diff / 86_400_000)
-    if (mins < 1) return t('time.justNow')
-    if (mins < 60) return t('time.minutesAgo', { n: mins })
-    if (hours < 24) return t('time.hoursAgo', { n: hours })
-    if (days < 30) return t('time.daysAgo', { n: days })
-    return new Date(dateStr).toLocaleDateString(locale.value, {
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric',
-    })
 }
 
 function isLightColor(hex: string): boolean {
@@ -638,11 +516,6 @@ onMounted(async () => {
 
 .stats-card {
     background: rgb(var(--v-theme-surface)) !important;
-}
-
-/* ── Review cards ────────────────────────────────────────────────────────── */
-.review-card {
-    transition: transform 0.15s ease;
 }
 
 /* ── Empty state icon animation ──────────────────────────────────────────── */

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -135,6 +135,7 @@
         "searchRouteName": "Suchen",
         "type": "Typ",
         "archived": "Archiviert",
+        "active": "Aktiv",
         "comment": "Kommentar",
         "creators": "Ersteller"
     },
@@ -147,7 +148,9 @@
         "difficulty": "Schwierigkeitsgrad",
         "score": "Punktzahl",
         "comment": "Kommentar",
-        "climber_reviews": "Kletterer Bewertungen"
+        "climber_reviews": "Kletterer Bewertungen",
+        "felt": "gefühlt",
+        "perceived_difficulty": "Gefühlte Schwierigkeit"
     },
     "table": {
         "actions": "Aktionen",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -135,6 +135,7 @@
         "searchRouteName": "Search",
         "type": "Type",
         "archived": "Archived",
+        "active": "Active",
         "comment": "Comment",
         "creators": "Creators"
     },
@@ -147,7 +148,9 @@
         "difficulty": "Difficulty",
         "score": "Score",
         "comment": "Comment",
-        "climber_reviews": "Climber Reviews"
+        "climber_reviews": "Climber Reviews",
+        "felt": "felt",
+        "perceived_difficulty": "Perceived difficulty"
     },
     "table": {
         "actions": "Actions",

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -135,6 +135,7 @@
         "searchRouteName": "Поиск",
         "type": "Тип",
         "archived": "Архивировано",
+        "active": "Активный",
         "comment": "Комментарий",
         "creators": "Создатели"
     },
@@ -147,7 +148,9 @@
         "difficulty": "Сложность",
         "score": "Оценка",
         "comment": "Комментарий",
-        "climber_reviews": "Отзывы скалолазов"
+        "climber_reviews": "Отзывы скалолазов",
+        "felt": "ощущение",
+        "perceived_difficulty": "Ощущаемая сложность"
     },
     "table": {
         "actions": "Действия",

--- a/i18n/locales/tr.json
+++ b/i18n/locales/tr.json
@@ -135,6 +135,7 @@
         "searchRouteName": "Ara",
         "type": "Tür",
         "archived": "Arşivlendi",
+        "active": "Aktif",
         "comment": "Yorum",
         "creators": "Yaratıcılar"
     },
@@ -147,7 +148,9 @@
         "difficulty": "Zorluk",
         "score": "Puan",
         "comment": "Yorum",
-        "climber_reviews": "Kaya Tırmanışı Değerlendirmeleri"
+        "climber_reviews": "Kaya Tırmanışı Değerlendirmeleri",
+        "felt": "hissedilen",
+        "perceived_difficulty": "Hissedilen zorluk"
     },
     "table": {
         "actions": "İşlemler",

--- a/i18n/locales/uk.json
+++ b/i18n/locales/uk.json
@@ -135,6 +135,7 @@
         "searchRouteName": "Пошук",
         "type": "Тип",
         "archived": "Архівовано",
+        "active": "Активний",
         "comment": "Коментар",
         "creators": "Автори"
     },
@@ -147,7 +148,9 @@
         "difficulty": "Складність",
         "score": "Оцінка",
         "comment": "Коментар",
-        "climber_reviews": "Відгуки скелелазів"
+        "climber_reviews": "Відгуки скелелазів",
+        "felt": "відчуття",
+        "perceived_difficulty": "Відчутна складність"
     },
     "table": {
         "actions": "Дії",

--- a/types/models.ts
+++ b/types/models.ts
@@ -41,6 +41,7 @@ export interface RouteListItem extends Omit<RouteRecord, 'creator'> {
     creator: string[]
     has_ratings?: boolean
     average_rating?: number | null
+    score?: number | null
 }
 
 export interface RatingRecord extends BaseRecord {


### PR DESCRIPTION
- Introduce reusable RouteCard and CommentsCard components aligned with shared UI design (tonal variant, header/meta/pills layout)
- Replace inline card implementations on /route, /admin/comments, and /admin/routes with reusable components

RouteFormDialog:
- Combine difficulty and sign into a single dropdown (e.g. '6-', '6', '6+')
- Reorganize form into structured 2-column layout (name; difficulty+type; anchor+location; route-setter; screwed-at+archived)
- Replace archived toggle with v-switch
- Add delete action with confirmation dialog
- Ensure color picker is always visible

CommentsCard:
- Add perceived difficulty pill with 'felt 6-' label, mdi-gauge icon, and tooltip
- Fix dark mode background issue in ReviewFormDialog

i18n:
- Add ratings.felt, ratings.perceived_difficulty, climbing.active
- Update all locales: en, de, ru, tr, uk