### PR TITLE
feat: add multi-tenancy with security hardening

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 # Now copy the rest needed to build
 COPY pocketbase/main.go ./
-COPY pocketbase/pb_hooks ./pb_hooks
 COPY pocketbase/pb_migrations ./pb_migrations
 
 # Compile to /out; -trimpath makes cache keys stable

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 # Now copy the rest needed to build
 COPY pocketbase/main.go ./
+COPY pocketbase/hooks.go ./
 COPY pocketbase/pb_migrations ./pb_migrations
 
 # Compile to /out; -trimpath makes cache keys stable

--- a/app/components/ImportRoute.vue
+++ b/app/components/ImportRoute.vue
@@ -99,6 +99,7 @@
 const pb = usePocketbase()
 const emit = defineEmits(['closed'])
 const currentUser = pb.authStore.model
+const { tenantId } = useTenant()
 
 const fileInput = ref(null)
 const showPreviewDialog = ref(false)
@@ -123,9 +124,17 @@ const open = () => {
 
 defineExpose({ open })
 
+const MAX_IMPORT_SIZE = 10 * 1024 * 1024 // 10 MB
+
 const handleFileChange = async (event) => {
     const file = event.target.files[0]
     if (!file) return
+
+    if (file.size > MAX_IMPORT_SIZE) {
+        showSnackbar('File too large. Maximum size is 10 MB.', 'error')
+        event.target.value = ''
+        return
+    }
 
     const reader = new FileReader()
     reader.onload = () => {
@@ -299,9 +308,8 @@ function sanitizeRatingPayload(rating, meta) {
         comment: typeof rating.comment === 'string' ? rating.comment : '',
     }
 
-    const userId = rating.user || meta.fallbackUserId
-    if (userId) {
-        payload.user = userId
+    if (meta.fallbackUserId) {
+        payload.user = meta.fallbackUserId
     }
 
     return payload

--- a/app/components/ReviewFormDialog.vue
+++ b/app/components/ReviewFormDialog.vue
@@ -157,6 +157,7 @@ const emit = defineEmits(['update:modelValue', 'saved'])
 
 const pb = usePocketbase()
 const { t } = useI18n()
+const { tenantId } = useTenant()
 
 const isEditMode = computed(() => !!props.review)
 

--- a/app/components/RouteFormDialog.vue
+++ b/app/components/RouteFormDialog.vue
@@ -193,6 +193,7 @@ import { required } from '~/utils/validation'
 
 const { t } = useI18n()
 const pb = usePocketbase() as PocketBase
+const { tenantId, tenantFilter } = useTenant()
 
 type VFormHandle = {
     validate: () => Promise<{ valid: boolean }>
@@ -239,7 +240,10 @@ const activePalette = computed(() =>
 
 async function fetchUsedColors() {
     try {
-        const records = await pb.collection('usedColors').getFullList<{ color: string }>({ fields: 'color' })
+        const filter = tenantId.value ? `tenant_id = "${tenantId.value}"` : undefined
+        const records = await pb
+            .collection('usedColors')
+            .getFullList<{ color: string }>({ fields: 'color', filter })
         usedColorsList.value = records.map((r) => r.color).filter(Boolean)
     } catch {
         usedColorsList.value = []
@@ -276,7 +280,22 @@ const form = reactive({
 const isEditMode = computed(() => editRouteId.value !== null)
 const isBoulderRoute = computed(() => form.type === 'Boulder')
 
-const locations = ['Hanau', 'Gelnhausen']
+// Dynamic locations from the locations collection (per tenant)
+const locationItems = ref<string[]>([])
+const locations = computed(() => locationItems.value)
+
+async function loadLocations() {
+    const tid = tenantId.value
+    if (!tid) return
+    try {
+        const records = await pb
+            .collection('locations')
+            .getFullList({ filter: `tenant_id = "${tid}"`, sort: 'order,name', fields: 'name' })
+        locationItems.value = records.map((r) => r.name as string)
+    } catch {
+        locationItems.value = []
+    }
+}
 
 const combinedDifficulties = Array.from({ length: 10 }, (_, i) => {
     const d = i + 1
@@ -372,7 +391,7 @@ const getSetters = async () => {
     try {
         const records = await pb
             .collection('routes')
-            .getFullList<RouteRecord>({ fields: 'creator', sort: '-created' })
+            .getFullList<RouteRecord>({ fields: 'creator', sort: '-created', filter: tenantFilter.value || undefined })
         const creators = records.flatMap((r) => normalizeCreators(r.creator))
         setterItems.value = Array.from(new Set(creators.filter(Boolean)))
     } catch (error) {
@@ -388,6 +407,7 @@ async function open(route?: RouteRecord) {
     }
     dialogOpen.value = true
     void getSetters()
+    void loadLocations()
     await fetchUsedColors()
     buildDefaultPalette()
     await nextTick()

--- a/app/components/layout/FootBar.vue
+++ b/app/components/layout/FootBar.vue
@@ -120,7 +120,7 @@ const versionUrl = computed(() => {
 
 const { data: health } = await useAsyncData(
     'footer:health',
-    () => pb.health.check(),
+    async () => (await pb.health.check()) ?? null,
     {
         default: () => null,
         lazy: true,
@@ -129,7 +129,7 @@ const { data: health } = await useAsyncData(
 
 const { data: online } = await useAsyncData(
     'footer:online',
-    () => pb.send('/api/online', { method: 'GET' }),
+    async () => (await pb.send('/api/online', { method: 'GET' })) ?? null,
     {
         default: () => ({ clients: 0 }),
         lazy: true,

--- a/app/components/layout/NavBar.vue
+++ b/app/components/layout/NavBar.vue
@@ -129,7 +129,7 @@ const props = defineProps({
 
 const { loggedIn, settings } = toRefs(props)
 
-const { can } = usePermissions()
+const { can, isSuperAdmin } = usePermissions()
 
 const navLinks = [
     {
@@ -177,8 +177,23 @@ const navLinks = [
     },
 ]
 
+const superAdminLinks = [
+    {
+        to: '/super-admin/tenants',
+        icon: 'mdi-domain',
+        label: 'Tenants',
+        permission: null,
+        superAdminOnly: true,
+    },
+]
+
+const allNavLinks = computed(() => [
+    ...navLinks,
+    ...(isSuperAdmin.value ? superAdminLinks : []),
+])
+
 const visibleNavLinks = computed(() =>
-    navLinks.filter((l) => !l.permission || can(l.permission)),
+    allNavLinks.value.filter((l) => !l.permission || can(l.permission)),
 )
 const desktopLinks = computed(() =>
     visibleNavLinks.value.filter((l) => !l.mobileOnly),

--- a/app/components/user/CreateUser.vue
+++ b/app/components/user/CreateUser.vue
@@ -169,6 +169,7 @@ import { required, maxLength, validEmail } from '~/utils/validation'
 const { t } = useI18n()
 const pb = usePocketbase()
 const emit = defineEmits(['user-created', 'closed'])
+const { tenantId } = useTenant()
 
 const dialog = ref(false)
 const valid = ref(false)
@@ -242,8 +243,12 @@ async function submit() {
             .toLowerCase()
             .replace(/[^a-z0-9]/g, '')
 
-        // Generate a random password (user will reset via email)
-        const randomPassword = crypto.randomUUID()
+        // Generate a random password (user will reset via email).
+        // Uses getRandomValues instead of randomUUID — works in non-secure HTTP contexts too.
+        const randomPassword = Array.from(
+            crypto.getRandomValues(new Uint8Array(32)),
+            (b) => b.toString(16).padStart(2, '0'),
+        ).join('')
 
         const formData = new FormData()
         formData.append('username', username)

--- a/app/composables/pocketbase.js
+++ b/app/composables/pocketbase.js
@@ -10,7 +10,22 @@ export const usePocketbase = () => {
 
     if (!globalThis._pb) {
         const url = import.meta.dev ? 'http://localhost:8090' : '/'
-        globalThis._pb = new PocketBase(url)
+        const pb = new PocketBase(url)
+
+        // Auto-inject X-Tenant-Id header on every SDK request so the Go hook
+        // can enforce tenant membership and auto-set tenant_id server-side.
+        pb.beforeSend = (url, options) => {
+            const { data: tenant } = useNuxtData('tenant')
+            if (tenant.value?.id) {
+                options.headers = {
+                    ...options.headers ?? {},
+                    'X-Tenant-Id': tenant.value.id,
+                }
+            }
+            return { url, options }
+        }
+
+        globalThis._pb = pb
     }
 
     return globalThis._pb

--- a/app/composables/useClimbingAnalytics.ts
+++ b/app/composables/useClimbingAnalytics.ts
@@ -86,12 +86,16 @@ export function useClimbingAnalytics() {
         error.value = false
 
         try {
+            const pb = usePocketbase()
+            const token = pb.authStore.token
             const response = await requestFetch<ClimbingAnalyticsResponse>(
                 '/api/admin/analytics',
+                token ? { headers: { Authorization: `Bearer ${token}` } } : {},
             )
 
             analytics.value = normalizeResponse(response)
-        } catch {
+        } catch (e) {
+            console.error('[analytics] fetch failed:', e)
             error.value = true
             analytics.value = null
         } finally {

--- a/app/composables/usePermissions.ts
+++ b/app/composables/usePermissions.ts
@@ -1,9 +1,8 @@
 export function usePermissions() {
     const pb = usePocketbase()
-    const permissions = useState<string[]>(
-        'user-permissions',
-        () => [],
-    )
+    const { tenantId } = useTenant()
+
+    const permissions = useState<string[]>('user-permissions', () => [])
     const roleName = useState<string>('user-role-name', () => '')
     const loading = ref(false)
     const loaded = useState<boolean>('user-permissions-loaded', () => false)
@@ -42,13 +41,44 @@ export function usePermissions() {
     }
 
     function can(featureName: string): boolean {
-        // Before permissions are loaded, allow navigation
-        // (PocketBase rules enforce server-side anyway)
-        if (!loaded.value) return true
-        // Admin safety net: always has all permissions
+        if (!loaded.value) return false
         if (roleName.value === 'admin') return true
         return permissions.value.includes(featureName)
     }
 
-    return { permissions, roleName, loading, loaded, can, ensureLoaded, refreshPermissions }
+    const isSuperAdmin = computed<boolean>(
+        () => !!(pb.authStore.record as any)?.is_super_admin,
+    )
+
+    /**
+     * Returns true if the current user is a member of the current tenant.
+     * Used as a guard — the PocketBase rules are the authoritative check.
+     */
+    async function isInCurrentTenant(): Promise<boolean> {
+        const userId = pb.authStore.record?.id
+        const tid = tenantId.value
+        if (!userId || !tid) return false
+        try {
+            await pb
+                .collection('tenant_users')
+                .getFirstListItem(`user_id = "${userId}" && tenant_id = "${tid}"`, {
+                    requestKey: 'tenantMembership',
+                })
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    return {
+        permissions,
+        roleName,
+        loading,
+        loaded,
+        can,
+        isSuperAdmin,
+        isInCurrentTenant,
+        ensureLoaded,
+        refreshPermissions,
+    }
 }

--- a/app/composables/useRouteFilters.ts
+++ b/app/composables/useRouteFilters.ts
@@ -1,5 +1,7 @@
 export function useRouteFilters() {
     const { t } = useI18n()
+    const pb = usePocketbase()
+    const { tenantId } = useTenant()
 
     const searchRouteName = ref('')
     const selectedDifficulty = ref('')
@@ -20,30 +22,59 @@ export function useRouteFilters() {
         { text: t('routes.types.boulder'), value: 'Boulder' },
     ])
 
+    // Dynamic locations fetched from the locations collection per tenant
+    const locationItems = ref<{ text: string; value: string }[]>([])
+
+    async function loadLocations() {
+        const tid = tenantId.value
+        if (!tid) {
+            locationItems.value = []
+            return
+        }
+        try {
+            const records = await pb
+                .collection('locations')
+                .getFullList({ filter: `tenant_id = "${tid}"`, sort: 'order,name' })
+            locationItems.value = records.map((r) => ({
+                text: r.name as string,
+                value: r.name as string,
+            }))
+        } catch {
+            locationItems.value = []
+        }
+    }
+
     const locations = computed(() => [
         { text: t('filter.all'), value: '' },
-        { text: 'Hanau', value: 'Hanau' },
-        { text: 'Gelnhausen', value: 'Gelnhausen' },
+        ...locationItems.value,
     ])
+
+    // Load locations when tenant changes
+    watch(tenantId, (tid) => {
+        if (tid) loadLocations()
+    }, { immediate: true })
 
     const activeFilterCount = computed(
         () =>
-            [
-                selectedDifficulty.value,
-                selectedType.value,
-                selectedLocation.value,
-            ].filter(Boolean).length,
+            [selectedDifficulty.value, selectedType.value, selectedLocation.value].filter(
+                Boolean,
+            ).length,
     )
 
     const pbFilter = computed(() => {
         const parts: string[] = []
         if (selectedDifficulty.value)
             parts.push(`difficulty = ${Number(selectedDifficulty.value)}`)
-        if (selectedLocation.value)
-            parts.push(`location = "${selectedLocation.value}"`)
-        if (selectedType.value) parts.push(`type = "${selectedType.value}"`)
+        if (selectedLocation.value) {
+            const loc = selectedLocation.value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+            parts.push(`location = "${loc}"`)
+        }
+        if (selectedType.value) {
+            const type = selectedType.value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+            parts.push(`type = "${type}"`)
+        }
         if (searchRouteName.value.trim()) {
-            const term = searchRouteName.value.trim().replace(/"/g, '\\"')
+            const term = searchRouteName.value.trim().replace(/\\/g, '\\\\').replace(/"/g, '\\"')
             parts.push(`name ~ "${term}"`)
         }
         return parts.join(' && ')
@@ -67,5 +98,6 @@ export function useRouteFilters() {
         activeFilterCount,
         pbFilter,
         clearFilters,
+        loadLocations,
     }
 }

--- a/app/composables/useTenant.ts
+++ b/app/composables/useTenant.ts
@@ -1,0 +1,20 @@
+export interface TenantInfo {
+    id: string
+    name: string
+    slug: string
+}
+
+export function useTenant() {
+    // Populated by useAsyncData('tenant', ...) in layouts/default.vue (SSR + hydration)
+    const { data: tenant } = useNuxtData<TenantInfo | null>('tenant')
+
+    const tenantId = computed<string | null>(() => tenant.value?.id ?? null)
+
+    // Use this as the base filter in every PocketBase query.
+    // Falls back to a never-match filter so UI shows nothing instead of all tenants.
+    const tenantFilter = computed<string>(() =>
+        tenantId.value ? `tenant_id = "${tenantId.value}"` : 'id = "___no_tenant___"',
+    )
+
+    return { tenant, tenantId, tenantFilter }
+}

--- a/app/layouts/blank.vue
+++ b/app/layouts/blank.vue
@@ -4,3 +4,7 @@
     </v-main>
     <GlobalSnackbar />
 </template>
+
+<script setup>
+await useAsyncData('tenant', () => $fetch('/api/tenant'))
+</script>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -15,34 +15,74 @@ const pb = usePocketbase()
 const isLoggedIn = ref(pb.authStore.isValid)
 const { refreshPermissions } = usePermissions()
 
-const getSettings = async () => {
+// ── Tenant detection (SSR-safe, keyed by hostname) ────────────────────────
+// Pass hostname as a query param — internal Nitro $fetch calls don't reliably
+// forward the Host header, so header-based forwarding breaks in SSR.
+const requestUrl = useRequestURL()
+const { data: tenantData } = await useAsyncData(
+    'tenant',
+    async () => (await $fetch('/api/tenant', { query: { host: requestUrl.hostname } })) ?? null,
+    { lazy: false },
+)
+
+// ── Auth-based tenant fallback ────────────────────────────────────────────
+// If domain resolution returns null (e.g. localhost dev with multiple tenants),
+// and the user is authenticated, resolve the tenant from their membership.
+// Runs client-only; picks the user's first active tenant membership.
+async function resolveTenantFromAuth() {
+    if (tenantData.value) return
+    if (!pb.authStore.isValid) return
     try {
-        return await pb.collection('settings').getOne('settings_123456')
-    } catch (error) {
-        if (error.data && error.data.code === 404) {
-            console.log('Settings not found, creating new settings')
-            try {
-                return await pb.collection('settings').create({
-                    id: 'settings_123456',
-                })
-            } catch (createError) {
-                console.error('Error creating new settings:', createError)
-                throw createError
-            }
+        const tu = await pb
+            .collection('tenant_users')
+            .getFirstListItem(`user_id = "${pb.authStore.record?.id}"`, {
+                expand: 'tenant_id',
+                sort: 'created',
+            })
+        const t = tu?.expand?.tenant_id
+        if (t?.id) {
+            tenantData.value = { id: t.id, name: t.name, slug: t.slug }
         }
-        console.error('An error occurred:', error)
-        throw error
+    } catch {
+        // no membership → leave as null
     }
 }
 
-const { data: settingsData } = await useAsyncData('settings', getSettings, {
-    lazy: true,
-})
+// ── Per-tenant settings ───────────────────────────────────────────────────
+const getSettings = async () => {
+    const tenantId = tenantData.value?.id
+    if (!tenantId) return {}
+    try {
+        return await pb
+            .collection('settings')
+            .getFirstListItem(`tenant_id = "${tenantId}"`)
+    } catch (error) {
+        if (error?.data?.code === 404 || error?.status === 404) {
+            return {}
+        }
+        console.error('An error occurred fetching settings:', error)
+        return {}
+    }
+}
+
+const { data: settingsData, refresh: refreshSettings } = await useAsyncData(
+    'settings',
+    getSettings,
+    { lazy: true },
+)
 
 const settings = ref(settingsData.value ?? {})
 watch(settingsData, (val) => {
     if (val) settings.value = val
 })
+
+// Re-fetch settings if the tenant changes (e.g., during dev HMR)
+watch(
+    () => tenantData.value?.id,
+    async (id) => {
+        if (id) await refreshSettings()
+    },
+)
 
 const refreshSession = async () => {
     try {
@@ -74,11 +114,9 @@ let unsubRole = null
 async function subscribeToRole(roleId) {
     unsubRole?.()?.catch?.(() => {})
     if (!roleId) return
-    unsubRole = await pb
-        .collection('roles')
-        .subscribe(roleId, (e) => {
-            if (e.action === 'update') refreshPermissions()
-        })
+    unsubRole = await pb.collection('roles').subscribe(roleId, (e) => {
+        if (e.action === 'update') refreshPermissions()
+    })
 }
 
 async function subscribeToUser(userId) {
@@ -90,7 +128,6 @@ async function subscribeToUser(userId) {
             const oldRole = pb.authStore.record?.role
             pb.authStore.save(pb.authStore.token, e.record)
             isLoggedIn.value = true
-            // If the user's role changed, refresh permissions and resubscribe
             if (e.record.role !== oldRole) {
                 refreshPermissions()
                 subscribeToRole(e.record.role)
@@ -105,14 +142,15 @@ onMounted(async () => {
             await refreshSession()
             await refreshPermissions()
         }
+        await resolveTenantFromAuth()
         setFavicon()
 
-        // Reflect any local auth store changes immediately (login/logout on this tab)
-        unsubAuthChange = pb.authStore.onChange((token, record) => {
+        unsubAuthChange = pb.authStore.onChange(async (token, record) => {
             isLoggedIn.value = !!token
             if (token && record?.id) {
                 subscribeToUser(record.id)
                 refreshPermissions()
+                await resolveTenantFromAuth()
             } else {
                 unsubUser?.()
                 unsubUser = null
@@ -120,23 +158,24 @@ onMounted(async () => {
             }
         })
 
-        // Subscribe to current user record for cross-device auth sync
         if (pb.authStore.isValid && pb.authStore.record?.id) {
             await subscribeToUser(pb.authStore.record.id)
         }
 
-        // Subscribe to role changes for realtime permission updates
         if (pb.authStore.isValid && pb.authStore.record?.role) {
             await subscribeToRole(pb.authStore.record.role)
         }
 
-        // Realtime settings sync across devices
-        unsubSettings = await pb
-            .collection('settings')
-            .subscribe('settings_123456', (e) => {
-                settings.value = e.record
-                setFavicon()
-            })
+        // Subscribe to per-tenant settings for realtime branding sync
+        const settingsRecord = settings.value
+        if (settingsRecord?.id) {
+            unsubSettings = await pb
+                .collection('settings')
+                .subscribe(settingsRecord.id, (e) => {
+                    settings.value = e.record
+                    setFavicon()
+                })
+        }
     } catch (error) {
         console.error('Error during initialization:', error)
     }

--- a/app/middleware/auth.js
+++ b/app/middleware/auth.js
@@ -5,6 +5,28 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
         const pb = usePocketbase()
         const isValidSession = pb.authStore.isValid
 
+        // Tenant membership guard — checked once per client session
+        const tenantOk = useState('auth_tenant_ok', () => null)
+        if (!isValidSession) {
+            tenantOk.value = null // reset on logout
+        } else if (tenantOk.value === null && !pb.authStore.record?.is_super_admin) {
+            try {
+                const tenant = await $fetch('/api/tenant').catch(() => null)
+                if (tenant?.id) {
+                    await pb
+                        .collection('tenant_users')
+                        .getFirstListItem(
+                            `tenant_id = "${tenant.id}" && user_id = "${pb.authStore.record?.id}"`,
+                        )
+                }
+                tenantOk.value = true
+            } catch {
+                tenantOk.value = false
+                pb.authStore.clear()
+                return navigateTo('/auth/login')
+            }
+        }
+
         // Pages that opt out of auth (login, password reset)
         if (to.meta.auth === false) {
             if (isValidSession) {
@@ -13,20 +35,30 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
             return
         }
 
-        // All non-root pages require authentication
-        if (to.path !== '/') {
+        // Super-admin pages require is_super_admin flag
+        if (to.path.startsWith('/super-admin')) {
             if (!isValidSession) {
                 return navigateTo('/auth/login')
             }
+            const isSuperAdmin = !!pb.authStore.record?.is_super_admin
+            if (!isSuperAdmin) {
+                return navigateTo('/')
+            }
+            return
+        }
 
-            // Permission check for admin pages
-            const requiredPermission = to.meta.requiredPermission
-            if (requiredPermission) {
-                const { can, ensureLoaded } = usePermissions()
-                await ensureLoaded()
-                if (!can(requiredPermission)) {
-                    return navigateTo('/')
-                }
+        // All pages require authentication (routes list is tenant-scoped and not public)
+        if (!isValidSession) {
+            return navigateTo('/auth/login')
+        }
+
+        // Permission check for admin pages
+        const requiredPermission = to.meta.requiredPermission
+        if (requiredPermission) {
+            const { can, ensureLoaded } = usePermissions()
+            await ensureLoaded()
+            if (!can(requiredPermission)) {
+                return navigateTo('/')
             }
         }
     }

--- a/app/pages/admin/comments.vue
+++ b/app/pages/admin/comments.vue
@@ -320,6 +320,7 @@ import { formatDifficulty } from '~/utils/formatting'
 
 const { t } = useI18n()
 const pb = usePocketbase()
+const { tenantFilter } = useTenant()
 
 useHead({
     title: t('page.title.comments'),
@@ -397,10 +398,24 @@ const difficulties = computed(() => [
     })),
 ])
 
+const { tenantId } = useTenant()
+const locationItems = ref([])
+async function loadCommentLocations() {
+    const tid = tenantId.value
+    if (!tid) return
+    try {
+        const records = await pb
+            .collection('locations')
+            .getFullList({ filter: `tenant_id = "${tid}"`, sort: 'order,name', fields: 'name' })
+        locationItems.value = records.map((r) => ({ text: r.name, value: r.name }))
+    } catch {
+        locationItems.value = []
+    }
+}
+onMounted(() => { void loadCommentLocations() })
 const locations = computed(() => [
     { text: t('filter.all'), value: null },
-    { text: 'Hanau', value: 'Hanau' },
-    { text: 'Gelnhausen', value: 'Gelnhausen' },
+    ...locationItems.value,
 ])
 
 const sortOptions = computed(() => [
@@ -433,7 +448,7 @@ const stats = computed(() => {
 // ── Query builders ─────────────────────────────────────────────────────────
 
 function buildFilter(searchTerm) {
-    const parts = []
+    const parts = [tenantFilter.value]
     if (selectedRating.value !== 0)
         parts.push(`rating = ${selectedRating.value}`)
     if (selectedLocation.value)
@@ -493,6 +508,7 @@ const fetchStats = async () => {
     try {
         const data = await pb.collection('ratings').getFullList({
             fields: 'id,rating,created',
+            filter: tenantFilter.value || undefined,
             requestKey: 'commentsStats',
         })
         statsData.value = data
@@ -558,6 +574,11 @@ watch(
     ],
     () => fetchList(),
 )
+
+watch(tenantFilter, () => {
+    fetchList()
+    fetchStats()
+})
 
 // ── Edit ───────────────────────────────────────────────────────────────────
 
@@ -634,6 +655,7 @@ onMounted(async () => {
             totalItems.value = Math.max(0, totalItems.value - 1)
             fetchStats()
         } else if (e.action === 'create') {
+            if (e.record.tenant_id !== tenantId.value) return
             totalItems.value++
             // Prepend to list only when showing newest-first on the first "page"
             if (sortOrder.value === 'newest' && !hasMore.value) {

--- a/app/pages/admin/routes.vue
+++ b/app/pages/admin/routes.vue
@@ -347,6 +347,7 @@ definePageMeta({
 const pb = usePocketbase()
 const { t, locale } = useI18n()
 const { smAndDown } = useDisplay()
+const { tenantFilter, tenantId } = useTenant()
 
 const isMobile = computed(() => smAndDown.value)
 
@@ -424,7 +425,7 @@ const tableHeaders = computed(() => [
 ])
 
 const pbFilter = computed(() => {
-    const parts = []
+    const parts = [tenantFilter.value]
     if (!displayArchived.value) parts.push('archived = false')
     const base = baseFilter.value
     if (base) parts.push(base)
@@ -573,7 +574,7 @@ const loadAverageRatings = async (force = false) => {
     try {
         const list = await pb
             .collection('averageRating')
-            .getFullList({ fields: 'id,average_rating' })
+            .getFullList({ fields: 'id,average_rating', filter: tenantFilter.value || undefined })
         averageRatings.value = new Map(
             list
                 .filter((record) => Boolean(record?.id))
@@ -639,6 +640,7 @@ const loadRoutes = async (options = {}) => {
         routes.value = normalizedRoutes
         totalItems.value = list.totalItems
     } catch (error) {
+        if (error?.isAbort) return
         console.error('Failed to load routes:', error)
     } finally {
         loading.value = false
@@ -701,9 +703,13 @@ const downloadExport = async (endpoint, extension, mimeType) => {
     if (!ids.length) return
 
     try {
+        const token = pb.authStore.token
         const response = await fetch(endpoint, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+                'Content-Type': 'application/json',
+                ...(token ? { Authorization: `Bearer ${token}` } : {}),
+            },
             body: JSON.stringify({ ids }),
         })
 

--- a/app/pages/admin/settings.vue
+++ b/app/pages/admin/settings.vue
@@ -245,6 +245,7 @@
 <script setup>
 const pb = usePocketbase()
 const { t } = useI18n()
+const { tenantId } = useTenant()
 
 useHead({
     title: t('page.title.settings'),
@@ -359,7 +360,7 @@ onMounted(async () => {
     // subscribe() returns a Promise<unsubscribe fn> in PocketBase JS SDK v0.21+
     unsubscribe = await pb
         .collection('settings')
-        .subscribe('settings_123456', (e) => {
+        .subscribe(settings.value?.id ?? '', (e) => {
             const d = e.record
             logoPreview.value = pbFileUrl(d, d.page_logo)
             iconPreview.value = pbFileUrl(d, d.page_icon)

--- a/app/pages/admin/users.vue
+++ b/app/pages/admin/users.vue
@@ -213,6 +213,7 @@
 <script setup>
 const { t } = useI18n()
 const pb = usePocketbase()
+const { tenantId } = useTenant()
 
 useHead({
     title: t('page.title.users'),
@@ -309,16 +310,42 @@ async function fetchList(append = false) {
     }
 
     try {
+        const tid = tenantId.value
+        if (!tid) {
+            users.value = []
+            totalItems.value = 0
+            return
+        }
+
+        // Fetch tenant members via tenant_users junction, then expand user data
+        const filterParts = [`tenant_id = "${tid}"`]
+        const userFilter = buildFilter()
+        if (userFilter) {
+            // Prefix each condition with user_id. to filter via relation
+            filterParts.push(
+                userFilter
+                    .split(' && ')
+                    .map((p) => `user_id.${p}`)
+                    .join(' && '),
+            )
+        }
+
         const result = await pb
-            .collection('users')
+            .collection('tenant_users')
             .getList(page.value, PER_PAGE, {
-                sort: '-created',
-                filter: buildFilter(),
-                expand: 'role',
+                filter: filterParts.join(' && '),
+                expand: 'user_id,user_id.role',
                 requestKey: 'usersList',
             })
+
         totalItems.value = result.totalItems
-        const mapped = result.items.map(mapUser)
+        const mapped = result.items
+            .map((tu) => {
+                const u = tu.expand?.user_id
+                if (!u) return null
+                return mapUser(u)
+            })
+            .filter(Boolean)
         users.value = append ? [...users.value, ...mapped] : mapped
     } catch (err) {
         if (err?.isAbort) return
@@ -374,14 +401,21 @@ function confirmDelete(user) {
 async function deleteUser() {
     deleting.value = true
     try {
-        await pb.collection('users').delete(deletingUser.value.id)
+        // Remove the user from this tenant only (tenant_users membership).
+        // Deleting the user record globally cascades across all tenants — never do that here.
+        const tu = await pb
+            .collection('tenant_users')
+            .getFirstListItem(
+                `tenant_id = "${tenantId.value}" && user_id = "${deletingUser.value.id}"`,
+            )
+        await pb.collection('tenant_users').delete(tu.id)
         users.value = users.value.filter((u) => u.id !== deletingUser.value.id)
         totalItems.value = Math.max(0, totalItems.value - 1)
         showSnackbar(t('users.deleteSuccess'))
         deleteDialog.value = false
         deletingUser.value = null
     } catch (err) {
-        console.error('Error deleting user:', err)
+        console.error('Error removing user from tenant:', err)
         showSnackbar(t('users.deleteError'), 'error')
     } finally {
         deleting.value = false
@@ -437,14 +471,9 @@ onMounted(async () => {
             users.value = users.value.filter((u) => u.id !== e.record.id)
             totalItems.value = Math.max(0, totalItems.value - 1)
         } else if (e.action === 'create') {
-            totalItems.value++
-            try {
-                const rec = await pb.collection('users').getOne(e.record.id, {
-                    expand: 'role',
-                    requestKey: null,
-                })
-                users.value = [mapUser(rec), ...users.value]
-            } catch {}
+            // Refetch instead of prepending — avoids double-display when the
+            // admin's own CreateUser dialog also triggers reloadUsers().
+            void fetchList()
         } else if (e.action === 'update') {
             const idx = users.value.findIndex((u) => u.id === e.record.id)
             if (idx !== -1) {

--- a/app/pages/auth/confirm-password-reset/[token].vue
+++ b/app/pages/auth/confirm-password-reset/[token].vue
@@ -116,9 +116,10 @@ const route = useRoute()
 
 definePageMeta({ layout: 'blank', auth: false })
 
+const { tenantFilter } = useTenant()
 let _settings = null
 try {
-    _settings = await pb.collection('settings').getOne('settings_123456')
+    _settings = await pb.collection('settings').getFirstListItem(tenantFilter.value)
 } catch {}
 const orgName = _settings?.organization_name || ''
 const orgUnitName = _settings?.organization_unit_name || ''

--- a/app/pages/auth/login.vue
+++ b/app/pages/auth/login.vue
@@ -253,9 +253,10 @@ const hasAnyAuth = !!(
     authMethods?.password?.enabled || authMethods?.oauth2?.enabled
 )
 
+const { tenantFilter } = useTenant()
 let _settings = null
 try {
-    _settings = await pb.collection('settings').getOne('settings_123456')
+    _settings = await pb.collection('settings').getFirstListItem(tenantFilter.value)
 } catch {}
 const orgName = _settings?.organization_name || ''
 const orgUnitName = _settings?.organization_unit_name || ''

--- a/app/pages/auth/login.vue
+++ b/app/pages/auth/login.vue
@@ -378,6 +378,23 @@ function resolveAuthError(err) {
     return msg || t('notifications.error.unknown')
 }
 
+// ── Tenant membership check ────────────────────────────────────────
+async function checkTenantMembership() {
+    if (pb.authStore.record?.is_super_admin) return true
+    try {
+        const tenant = await $fetch('/api/tenant').catch(() => null)
+        if (!tenant?.id) return true
+        await pb
+            .collection('tenant_users')
+            .getFirstListItem(
+                `tenant_id = "${tenant.id}" && user_id = "${pb.authStore.record?.id}"`,
+            )
+        return true
+    } catch {
+        return false
+    }
+}
+
 // ── Auth handlers ──────────────────────────────────────────────────
 async function submitLogin() {
     if (!(await validate(loginForm))) return
@@ -388,6 +405,14 @@ async function submitLogin() {
             .authWithPassword(identity.value, password.value, {
                 autoRefreshThreshold: 0,
             })
+        if (!(await checkTenantMembership())) {
+            pb.authStore.clear()
+            layout.value.notify(
+                t('notifications.error.not_authorized_for_org', 'Not authorized for this organization.'),
+                'error',
+            )
+            return
+        }
         layout.value.notify(t('notifications.success.login'), 'success')
         await navigateTo('/admin/routes', { replace: true })
     } catch (err) {
@@ -416,6 +441,14 @@ async function loginWithOAuth(provider) {
     loading.value = true
     try {
         await pb.collection('users').authWithOAuth2({ provider })
+        if (!(await checkTenantMembership())) {
+            pb.authStore.clear()
+            layout.value.notify(
+                t('notifications.error.not_authorized_for_org', 'Not authorized for this organization.'),
+                'error',
+            )
+            return
+        }
         layout.value.notify(t('notifications.success.login'), 'success')
         await navigateTo('/admin/routes', { replace: true })
     } catch (err) {

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -172,6 +172,7 @@ import { toPbSort } from '~/utils/sorting'
 const { t } = useI18n()
 const pb = usePocketbase() as PocketBase
 const { smAndDown, mdAndUp } = useDisplay()
+const { tenantFilter } = useTenant()
 
 const {
     searchRouteName,
@@ -236,8 +237,9 @@ const headersDesktop: Array<{
 ]
 
 const pbFilter = computed(() => {
-    const base = baseFilter.value
-    return base ? `archived = false && ${base}` : 'archived = false'
+    const parts = [tenantFilter.value, 'archived = false']
+    if (baseFilter.value) parts.push(baseFilter.value)
+    return parts.join(' && ')
 })
 
 const toPbSortIndex = (sortByArr: SortOption[]) =>
@@ -273,7 +275,10 @@ async function loadRoutes(
 
         if (routeIds.length > 0) {
             try {
-                const filter = routeIds.map((id) => `id = "${id}"`).join(' || ')
+                const idFilter = routeIds.map((id) => `id = "${id}"`).join(' || ')
+                const filter = tenantFilter.value
+                    ? `(${idFilter}) && ${tenantFilter.value}`
+                    : idFilter
                 const avgRecords = await pb
                     .collection('averageRating')
                     .getFullList<AverageRatingRecord>({
@@ -306,6 +311,7 @@ async function loadRoutes(
 
         totalItems.value = res.totalItems
     } catch (error) {
+        if ((error as any)?.isAbort) return
         console.error('Failed to load routes:', error)
     } finally {
         loading.value = false

--- a/app/pages/route.vue
+++ b/app/pages/route.vue
@@ -263,6 +263,7 @@ import { formatDifficulty, normalizeCreators } from '~/utils/formatting'
 const { t, locale } = useI18n()
 const pb = usePocketbase() as PocketBase
 const nuxtRoute = useRoute()
+const { tenantFilter, tenantId } = useTenant()
 
 const route_id = ref<string | null>((nuxtRoute.query.id as string) || null)
 const loading = ref(true)
@@ -353,7 +354,9 @@ const getRouteMetadata = async (): Promise<void> => {
     try {
         const record = await pb
             .collection('routes')
-            .getOne<RouteRecord>(route_id.value)
+            .getFirstListItem<RouteRecord>(
+                `id = "${route_id.value}" && ${tenantFilter.value}`,
+            )
         metadata.value = {
             ...record,
             creator: normalizeCreators(record.creator),
@@ -367,7 +370,7 @@ const getAllRouteRatings = async (): Promise<void> => {
     if (!route_id.value) return
     try {
         const data = await pb.collection('ratings').getFullList<RatingRecord>({
-            filter: `route_id = "${route_id.value}"`,
+            filter: `route_id = "${route_id.value}" && ${tenantFilter.value}`,
             sort: '-created',
             expand: 'user',
             requestKey: 'routeRatings',
@@ -447,7 +450,7 @@ onMounted(async () => {
     loading.value = false
 
     await subscribe('ratings', (event) => {
-        if (event.record.route_id === route_id.value) {
+        if (event.record.route_id === route_id.value && event.record.tenant_id === tenantId.value) {
             void getAllRouteRatings()
         }
     })

--- a/app/pages/super-admin/tenants.vue
+++ b/app/pages/super-admin/tenants.vue
@@ -1,0 +1,415 @@
+<template>
+    <v-container fluid class="pa-6">
+        <div class="d-flex align-center justify-space-between mb-6">
+            <div>
+                <h1 class="text-h5 font-weight-bold">Tenant Management</h1>
+                <p class="text-caption text-medium-emphasis mt-1">
+                    Super-admin only — manage all gyms / organizations
+                </p>
+            </div>
+            <v-btn
+                color="primary"
+                variant="tonal"
+                rounded="lg"
+                prepend-icon="mdi-plus"
+                @click="openCreate"
+            >
+                New Tenant
+            </v-btn>
+        </div>
+
+        <!-- Tenant list -->
+        <v-row>
+            <v-col
+                v-for="tenant in tenants"
+                :key="tenant.id"
+                cols="12"
+                md="6"
+                lg="4"
+            >
+                <v-card rounded="xl" border flat>
+                    <v-card-item>
+                        <v-card-title class="text-body-1 font-weight-semibold">
+                            {{ tenant.name }}
+                        </v-card-title>
+                        <v-card-subtitle class="text-caption">
+                            slug: <code>{{ tenant.slug }}</code>
+                        </v-card-subtitle>
+                        <template #append>
+                            <v-chip
+                                :color="tenant.active ? 'success' : 'error'"
+                                size="x-small"
+                                variant="tonal"
+                            >
+                                {{ tenant.active ? 'Active' : 'Inactive' }}
+                            </v-chip>
+                        </template>
+                    </v-card-item>
+
+                    <v-card-text class="pt-0">
+                        <div class="text-caption text-medium-emphasis">
+                            <strong>Custom domains:</strong>
+                            <span v-if="tenant.domains?.length">
+                                {{ tenant.domains.join(', ') }}
+                            </span>
+                            <span v-else class="text-disabled">none</span>
+                        </div>
+                    </v-card-text>
+
+                    <v-card-actions class="pt-0">
+                        <v-btn
+                            size="small"
+                            variant="text"
+                            prepend-icon="mdi-pencil-outline"
+                            @click="openEdit(tenant)"
+                        >
+                            Edit
+                        </v-btn>
+                        <v-btn
+                            size="small"
+                            variant="text"
+                            prepend-icon="mdi-account-group-outline"
+                            @click="openMembers(tenant)"
+                        >
+                            Members
+                        </v-btn>
+                        <v-spacer />
+                        <v-btn
+                            size="small"
+                            variant="text"
+                            color="error"
+                            icon
+                            @click="confirmDelete(tenant)"
+                        >
+                            <v-icon size="18">mdi-delete-outline</v-icon>
+                        </v-btn>
+                    </v-card-actions>
+                </v-card>
+            </v-col>
+        </v-row>
+
+        <!-- Create / Edit dialog -->
+        <v-dialog v-model="formDialog" max-width="520" scrollable>
+            <v-card>
+                <v-card-title class="pa-4 pb-3">
+                    {{ editingTenant ? 'Edit Tenant' : 'New Tenant' }}
+                </v-card-title>
+                <v-divider />
+                <v-card-text class="pa-4">
+                    <v-text-field
+                        v-model="form.name"
+                        label="Name"
+                        density="compact"
+                        variant="outlined"
+                        rounded="md"
+                        class="mb-3"
+                    />
+                    <v-text-field
+                        v-model="form.slug"
+                        label="Slug (subdomain)"
+                        density="compact"
+                        variant="outlined"
+                        rounded="md"
+                        hint="Used for subdomain detection: slug.yourdomain.com"
+                        persistent-hint
+                        class="mb-3"
+                    />
+                    <v-textarea
+                        v-model="form.domainsRaw"
+                        label="Custom domains (one per line)"
+                        density="compact"
+                        variant="outlined"
+                        rounded="md"
+                        rows="3"
+                        hint="e.g. gym1.example.com"
+                        persistent-hint
+                        class="mb-3"
+                    />
+                    <v-switch
+                        v-model="form.active"
+                        label="Active"
+                        color="primary"
+                        density="compact"
+                        hide-details
+                    />
+                </v-card-text>
+                <v-card-actions class="pa-4 pt-0">
+                    <v-spacer />
+                    <v-btn variant="text" @click="formDialog = false">Cancel</v-btn>
+                    <v-btn
+                        color="primary"
+                        variant="tonal"
+                        rounded="md"
+                        :loading="saving"
+                        @click="saveTenant"
+                    >
+                        Save
+                    </v-btn>
+                </v-card-actions>
+            </v-card>
+        </v-dialog>
+
+        <!-- Members dialog -->
+        <v-dialog v-model="membersDialog" max-width="600" scrollable>
+            <v-card>
+                <v-card-title class="pa-4 pb-3">
+                    Members — {{ membersTenant?.name }}
+                </v-card-title>
+                <v-divider />
+                <v-card-text class="pa-4">
+                    <!-- Add user form -->
+                    <div class="d-flex ga-2 mb-4">
+                        <v-autocomplete
+                            v-model="newMemberUserId"
+                            :items="allUsers"
+                            item-title="username"
+                            item-value="id"
+                            label="Add user"
+                            density="compact"
+                            variant="outlined"
+                            rounded="md"
+                            hide-details
+                            clearable
+                        />
+                        <v-btn
+                            color="primary"
+                            variant="tonal"
+                            rounded="md"
+                            :loading="addingMember"
+                            :disabled="!newMemberUserId"
+                            @click="addMember"
+                        >
+                            Add
+                        </v-btn>
+                    </div>
+
+                    <!-- Member list -->
+                    <v-list density="compact" lines="one">
+                        <v-list-item
+                            v-for="tu in members"
+                            :key="tu.id"
+                            :title="tu.expand?.user_id?.username ?? tu.user_id"
+                            :subtitle="tu.expand?.user_id?.email"
+                        >
+                            <template #append>
+                                <v-btn
+                                    icon
+                                    size="x-small"
+                                    variant="text"
+                                    color="error"
+                                    @click="removeMember(tu)"
+                                >
+                                    <v-icon size="16">mdi-close</v-icon>
+                                </v-btn>
+                            </template>
+                        </v-list-item>
+                        <v-list-item
+                            v-if="!members.length"
+                            title="No members yet"
+                            class="text-medium-emphasis"
+                        />
+                    </v-list>
+                </v-card-text>
+            </v-card>
+        </v-dialog>
+
+        <!-- Delete confirmation -->
+        <ConfirmDialog
+            v-model="deleteDialog"
+            title="Delete Tenant"
+            :message="`Permanently delete '${deletingTenant?.name}'? All tenant data (routes, ratings, settings) will be deleted.`"
+            confirm-color="error"
+            confirm-text="Delete"
+            :loading="deleting"
+            @confirm="deleteTenant"
+        />
+    </v-container>
+</template>
+
+<script setup>
+const pb = usePocketbase()
+const { notify } = useNotification()
+
+definePageMeta({
+    middleware: ['auth'],
+})
+
+useHead({ title: 'Tenant Management' })
+
+// ── State ─────────────────────────────────────────────────────────────────
+
+const tenants = ref([])
+const loading = ref(false)
+
+const formDialog = ref(false)
+const editingTenant = ref(null)
+const saving = ref(false)
+const form = reactive({
+    name: '',
+    slug: '',
+    domainsRaw: '',
+    active: true,
+})
+
+const deleteDialog = ref(false)
+const deletingTenant = ref(null)
+const deleting = ref(false)
+
+const membersDialog = ref(false)
+const membersTenant = ref(null)
+const members = ref([])
+const allUsers = ref([])
+const newMemberUserId = ref(null)
+const addingMember = ref(false)
+
+// ── Data ──────────────────────────────────────────────────────────────────
+
+async function fetchTenants() {
+    loading.value = true
+    try {
+        tenants.value = await pb
+            .collection('tenants')
+            .getFullList({ sort: 'name' })
+    } catch (err) {
+        console.error(err)
+    } finally {
+        loading.value = false
+    }
+}
+
+// ── Create / Edit ─────────────────────────────────────────────────────────
+
+function openCreate() {
+    editingTenant.value = null
+    Object.assign(form, { name: '', slug: '', domainsRaw: '', active: true })
+    formDialog.value = true
+}
+
+function openEdit(tenant) {
+    editingTenant.value = tenant
+    Object.assign(form, {
+        name: tenant.name,
+        slug: tenant.slug,
+        domainsRaw: (tenant.domains ?? []).join('\n'),
+        active: tenant.active ?? true,
+    })
+    formDialog.value = true
+}
+
+async function saveTenant() {
+    saving.value = true
+    try {
+        const payload = {
+            name: form.name,
+            slug: form.slug,
+            domains: form.domainsRaw
+                .split('\n')
+                .map((d) => d.trim())
+                .filter(Boolean),
+            active: form.active,
+        }
+        if (editingTenant.value) {
+            await pb.collection('tenants').update(editingTenant.value.id, payload)
+        } else {
+            await pb.collection('tenants').create(payload)
+        }
+        formDialog.value = false
+        await fetchTenants()
+        notify('Tenant saved.')
+    } catch (err) {
+        console.error(err)
+        notify('Failed to save tenant.', 'error')
+    } finally {
+        saving.value = false
+    }
+}
+
+// ── Delete ────────────────────────────────────────────────────────────────
+
+function confirmDelete(tenant) {
+    deletingTenant.value = tenant
+    deleteDialog.value = true
+}
+
+async function deleteTenant() {
+    if (!deletingTenant.value) return
+    deleting.value = true
+    try {
+        await pb.collection('tenants').delete(deletingTenant.value.id)
+        deleteDialog.value = false
+        await fetchTenants()
+        notify('Tenant deleted.')
+    } catch (err) {
+        console.error(err)
+        notify('Failed to delete tenant.', 'error')
+    } finally {
+        deleting.value = false
+    }
+}
+
+// ── Members ───────────────────────────────────────────────────────────────
+
+async function openMembers(tenant) {
+    membersTenant.value = tenant
+    membersDialog.value = true
+    await Promise.all([fetchMembers(tenant.id), fetchAllUsers()])
+}
+
+async function fetchMembers(tenantId) {
+    try {
+        members.value = await pb
+            .collection('tenant_users')
+            .getFullList({
+                filter: `tenant_id = "${tenantId}"`,
+                expand: 'user_id',
+                sort: 'user_id.username',
+            })
+    } catch (err) {
+        members.value = []
+    }
+}
+
+async function fetchAllUsers() {
+    try {
+        allUsers.value = await pb
+            .collection('users')
+            .getFullList({ sort: 'username', fields: 'id,username,email' })
+    } catch {
+        allUsers.value = []
+    }
+}
+
+async function addMember() {
+    if (!newMemberUserId.value || !membersTenant.value) return
+    addingMember.value = true
+    try {
+        await pb.collection('tenant_users').create({
+            tenant_id: membersTenant.value.id,
+            user_id: newMemberUserId.value,
+        })
+        newMemberUserId.value = null
+        await fetchMembers(membersTenant.value.id)
+        notify('User added to tenant.')
+    } catch (err) {
+        console.error(err)
+        notify('Failed to add user.', 'error')
+    } finally {
+        addingMember.value = false
+    }
+}
+
+async function removeMember(tu) {
+    try {
+        await pb.collection('tenant_users').delete(tu.id)
+        await fetchMembers(membersTenant.value.id)
+        notify('User removed from tenant.')
+    } catch (err) {
+        console.error(err)
+        notify('Failed to remove user.', 'error')
+    }
+}
+
+// ── Init ──────────────────────────────────────────────────────────────────
+
+onMounted(fetchTenants)
+</script>

--- a/app/types/models.ts
+++ b/app/types/models.ts
@@ -75,6 +75,25 @@ export interface UserRecord extends BaseRecord {
     lastname?: string | null
     avatar?: string | null
     role?: RecordId | null
+    is_super_admin?: boolean
+}
+
+export interface TenantRecord extends BaseRecord {
+    name: string
+    slug: string
+    domains?: string[]
+    active?: boolean
+}
+
+export interface TenantUserRecord extends BaseRecord {
+    tenant_id: RecordId
+    user_id: RecordId
+}
+
+export interface LocationRecord extends BaseRecord {
+    tenant_id: RecordId
+    name: string
+    order?: number
 }
 
 export interface SettingsRecord extends BaseRecord {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "scripts": {
         "build": "nuxt build",
-        "dev": "concurrently \"nuxt dev\" \"npm run start:db\"",
+        "dev": "concurrently \"nuxt dev --host 0.0.0.0\" \"npm run start:db\"",
         "start:db": "cd pocketbase && ./pocketbase serve --http=0.0.0.0:8090",
         "generate": "nuxt generate",
         "preview": "nuxt preview",

--- a/pocketbase/go.mod
+++ b/pocketbase/go.mod
@@ -4,7 +4,10 @@ go 1.25.0
 
 toolchain go1.25.1
 
-require github.com/pocketbase/pocketbase v0.38.0
+require (
+	github.com/pocketbase/dbx v1.12.0
+	github.com/pocketbase/pocketbase v0.38.0
+)
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
@@ -30,7 +33,6 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/pocketbase/dbx v1.12.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect

--- a/pocketbase/hooks.go
+++ b/pocketbase/hooks.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/apis"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+func registerHooks(app core.App) {
+	registerRoutes(app)
+	registerSideEffectHooks(app)
+	registerTenantEnforcement(app)
+}
+
+// ── Custom API routes ─────────────────────────────────────────────────────────
+
+func registerRoutes(app core.App) {
+	app.OnServe().BindFunc(func(se *core.ServeEvent) error {
+		// Resolve a tenant from a domain name.
+		// Steps: (1) exact domain match, (2) slug-as-first-subdomain, (3) single-tenant fallback.
+		se.Router.GET("/api/tenant-by-domain", func(e *core.RequestEvent) error {
+			domain := e.Request.URL.Query().Get("domain")
+			if domain == "" {
+				return e.JSON(http.StatusBadRequest, map[string]string{"error": "domain required"})
+			}
+
+			var tenant *core.Record
+
+			// 1. Exact custom domain match (JSON array field contains the domain)
+			tenant, _ = e.App.FindFirstRecordByFilter(
+				"tenants",
+				"domains ~ {:domain} && active = true",
+				dbx.Params{"domain": domain},
+			)
+
+			// 2. Slug matches the first subdomain segment (e.g. "acme" in acme.example.com)
+			if tenant == nil {
+				slug := strings.SplitN(domain, ".", 2)[0]
+				tenant, _ = e.App.FindFirstRecordByFilter(
+					"tenants",
+					"slug = {:slug} && active = true",
+					dbx.Params{"slug": slug},
+				)
+			}
+
+			// 3. Single-tenant fallback: return the only active tenant regardless of domain
+			if tenant == nil {
+				tenants, err := e.App.FindRecordsByFilter("tenants", "active = true", "", 2, 0)
+				if err == nil && len(tenants) == 1 {
+					tenant = tenants[0]
+				}
+			}
+
+			if tenant == nil {
+				return e.JSON(http.StatusNotFound, map[string]string{"error": "tenant not found"})
+			}
+
+			return e.JSON(http.StatusOK, map[string]string{
+				"id":   tenant.Id,
+				"name": tenant.GetString("name"),
+				"slug": tenant.GetString("slug"),
+			})
+		})
+
+		return se.Next()
+	})
+}
+
+// ── Side-effect hooks ─────────────────────────────────────────────────────────
+
+func registerSideEffectHooks(app core.App) {
+	// Auto-create a settings record whenever a new tenant is created.
+	app.OnRecordAfterCreateSuccess("tenants").BindFunc(func(e *core.RecordEvent) error {
+		settingsCol, err := e.App.FindCollectionByNameOrId("settings")
+		if err != nil {
+			return e.Next()
+		}
+		newSettings := core.NewRecord(settingsCol)
+		newSettings.Set("tenant_id", e.Record.Id)
+		if err := e.App.SaveNoValidate(newSettings); err != nil {
+			slog.Error("failed to auto-create settings for tenant", "tenant_id", e.Record.Id, "error", err)
+		}
+		return e.Next()
+	})
+
+	// Auto-assign a newly created user to the tenant indicated by the X-Tenant-Id header.
+	// Uses post-next pattern: capture header before save, create tenant_users after save
+	// (e.Record.Id is only available once e.Next() has returned successfully).
+	app.OnRecordCreateRequest("users").BindFunc(func(e *core.RecordRequestEvent) error {
+		tenantId := e.Request.Header.Get("X-Tenant-Id")
+
+		if err := e.Next(); err != nil {
+			return err
+		}
+
+		if tenantId == "" {
+			return nil
+		}
+
+		tuCol, err := e.App.FindCollectionByNameOrId("tenant_users")
+		if err != nil {
+			return nil
+		}
+		tu := core.NewRecord(tuCol)
+		tu.Set("tenant_id", tenantId)
+		tu.Set("user_id", e.Record.Id)
+		if err := e.App.SaveNoValidate(tu); err != nil {
+			slog.Error("failed to auto-assign user to tenant", "tenant_id", tenantId, "user_id", e.Record.Id, "error", err)
+		}
+		return nil
+	})
+}
+
+// ── Tenant enforcement: auto-inject tenant_id on record create ────────────────
+
+func registerTenantEnforcement(app core.App) {
+	// The client sends X-Tenant-Id header (set globally via pb.beforeSend in the
+	// Nuxt frontend). The hook verifies the authenticated user is a member of the
+	// claimed tenant, then sets tenant_id on the record — ignoring whatever value
+	// the client body may have included.
+	app.OnRecordCreateRequest("routes", "ratings", "locations").BindFunc(
+		func(e *core.RecordRequestEvent) error {
+			tenantId := e.Request.Header.Get("X-Tenant-Id")
+			if tenantId == "" {
+				return apis.NewBadRequestError("X-Tenant-Id header is required", nil)
+			}
+
+			if e.Auth == nil {
+				return apis.NewUnauthorizedError("authentication required", nil)
+			}
+
+			// Verify user is a member of the claimed tenant
+			_, err := e.App.FindFirstRecordByFilter(
+				"tenant_users",
+				"tenant_id = {:tenantId} && user_id = {:userId}",
+				dbx.Params{"tenantId": tenantId, "userId": e.Auth.Id},
+			)
+			if err != nil {
+				// Super-admins bypass tenant membership check
+				if !e.Auth.GetBool("is_super_admin") {
+					return apis.NewApiError(http.StatusForbidden, "not a member of this tenant", nil)
+				}
+			}
+
+			// Server authority: set tenant_id, overriding any client-supplied value
+			e.Record.Set("tenant_id", tenantId)
+
+			return e.Next()
+		},
+	)
+}

--- a/pocketbase/hooks.go
+++ b/pocketbase/hooks.go
@@ -118,11 +118,8 @@ func registerSideEffectHooks(app core.App) {
 // ── Tenant enforcement: auto-inject tenant_id on record create ────────────────
 
 func registerTenantEnforcement(app core.App) {
-	// The client sends X-Tenant-Id header (set globally via pb.beforeSend in the
-	// Nuxt frontend). The hook verifies the authenticated user is a member of the
-	// claimed tenant, then sets tenant_id on the record — ignoring whatever value
-	// the client body may have included.
-	app.OnRecordCreateRequest("routes", "ratings", "locations").BindFunc(
+	// Routes and locations require authentication + tenant membership.
+	app.OnRecordCreateRequest("routes", "locations").BindFunc(
 		func(e *core.RecordRequestEvent) error {
 			tenantId := e.Request.Header.Get("X-Tenant-Id")
 			if tenantId == "" {
@@ -146,9 +143,29 @@ func registerTenantEnforcement(app core.App) {
 				}
 			}
 
-			// Server authority: set tenant_id, overriding any client-supplied value
 			e.Record.Set("tenant_id", tenantId)
+			return e.Next()
+		},
+	)
 
+	// Ratings allow unauthenticated submission — verify tenant exists but skip auth check.
+	app.OnRecordCreateRequest("ratings").BindFunc(
+		func(e *core.RecordRequestEvent) error {
+			tenantId := e.Request.Header.Get("X-Tenant-Id")
+			if tenantId == "" {
+				return apis.NewBadRequestError("X-Tenant-Id header is required", nil)
+			}
+
+			_, err := e.App.FindFirstRecordByFilter(
+				"tenants",
+				"id = {:tenantId} && active = true",
+				dbx.Params{"tenantId": tenantId},
+			)
+			if err != nil {
+				return apis.NewNotFoundError("tenant not found", nil)
+			}
+
+			e.Record.Set("tenant_id", tenantId)
 			return e.Next()
 		},
 	)

--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -118,6 +118,9 @@ func main() {
 		return se.Next()
 	})
 
+	// Register Go hooks (tenant enforcement, etc.)
+	registerHooks(app)
+
 	if err := app.Start(); err != nil {
 		log.Fatal(err)
 	}

--- a/pocketbase/pb_hooks/main.pb.js
+++ b/pocketbase/pb_hooks/main.pb.js
@@ -1,6 +1,0 @@
-routerAdd('GET', '/', (c) => {
-    return c.json(200, {
-        message:
-            'This is only the pocketbase server. Please visit https://pocketbase.io for more information.',
-    })
-})

--- a/pocketbase/pb_migrations/1776000001_multitenancy.js
+++ b/pocketbase/pb_migrations/1776000001_multitenancy.js
@@ -1,0 +1,597 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+    (app) => {
+        // ── 1. tenants collection ──────────────────────────────────────────
+        const tenantsCollection = new Collection({
+            id: 'tenants_col_id001',
+            name: 'tenants',
+            type: 'base',
+            system: false,
+            listRule: '',
+            viewRule: '',
+            createRule: null,
+            updateRule: null,
+            deleteRule: null,
+            fields: [
+                {
+                    id: 'text3208210256',
+                    name: 'id',
+                    type: 'text',
+                    primaryKey: true,
+                    system: true,
+                    required: true,
+                    autogeneratePattern: '[a-z0-9]{15}',
+                    min: 15,
+                    max: 15,
+                    pattern: '^[a-z0-9]+$',
+                    hidden: false,
+                    presentable: false,
+                },
+                {
+                    id: 'tenants_name',
+                    name: 'name',
+                    type: 'text',
+                    required: true,
+                    min: 1,
+                    max: 100,
+                    hidden: false,
+                    presentable: true,
+                    primaryKey: false,
+                    system: false,
+                },
+                {
+                    id: 'tenants_slug',
+                    name: 'slug',
+                    type: 'text',
+                    required: true,
+                    min: 1,
+                    max: 50,
+                    pattern: '^[a-z0-9-]+$',
+                    hidden: false,
+                    presentable: false,
+                    primaryKey: false,
+                    system: false,
+                },
+                {
+                    id: 'tenants_domains',
+                    name: 'domains',
+                    type: 'json',
+                    required: false,
+                    maxSize: 5000,
+                    hidden: false,
+                    presentable: false,
+                    system: false,
+                },
+                {
+                    id: 'tenants_active',
+                    name: 'active',
+                    type: 'bool',
+                    required: false,
+                    hidden: false,
+                    presentable: false,
+                    system: false,
+                },
+                {
+                    id: 'tenants_created',
+                    name: 'created',
+                    type: 'autodate',
+                    onCreate: true,
+                    onUpdate: false,
+                    hidden: false,
+                    presentable: false,
+                    system: false,
+                },
+                {
+                    id: 'tenants_updated',
+                    name: 'updated',
+                    type: 'autodate',
+                    onCreate: true,
+                    onUpdate: true,
+                    hidden: false,
+                    presentable: false,
+                    system: false,
+                },
+            ],
+            indexes: ['CREATE UNIQUE INDEX `idx_tenants_slug` ON `tenants` (`slug`)'],
+        })
+        app.save(tenantsCollection)
+
+        // ── 2. tenant_users collection ────────────────────────────────────
+        const tenantUsersCollection = new Collection({
+            id: 'tenant_users_col',
+            name: 'tenant_users',
+            type: 'base',
+            system: false,
+            listRule: '@request.auth.id != "" && (user_id = @request.auth.id || @request.auth.role.permissions.name ?= "manage_users")',
+            viewRule: '@request.auth.id != "" && (user_id = @request.auth.id || @request.auth.role.permissions.name ?= "manage_users")',
+            createRule: '@request.auth.id != "" && @request.auth.is_super_admin = true',
+            updateRule: '@request.auth.id != "" && @request.auth.is_super_admin = true',
+            deleteRule: '@request.auth.id != "" && @request.auth.is_super_admin = true',
+            fields: [
+                {
+                    id: 'text3208210256',
+                    name: 'id',
+                    type: 'text',
+                    primaryKey: true,
+                    system: true,
+                    required: true,
+                    autogeneratePattern: '[a-z0-9]{15}',
+                    min: 15,
+                    max: 15,
+                    pattern: '^[a-z0-9]+$',
+                    hidden: false,
+                    presentable: false,
+                },
+                {
+                    id: 'tu_tenant_id',
+                    name: 'tenant_id',
+                    type: 'relation',
+                    collectionId: 'tenants_col_id001',
+                    maxSelect: 1,
+                    minSelect: 0,
+                    required: true,
+                    cascadeDelete: true,
+                    hidden: false,
+                    presentable: false,
+                    system: false,
+                },
+                {
+                    id: 'tu_user_id',
+                    name: 'user_id',
+                    type: 'relation',
+                    collectionId: '_pb_users_auth_',
+                    maxSelect: 1,
+                    minSelect: 0,
+                    required: true,
+                    cascadeDelete: true,
+                    hidden: false,
+                    presentable: false,
+                    system: false,
+                },
+                {
+                    id: 'tu_created',
+                    name: 'created',
+                    type: 'autodate',
+                    onCreate: true,
+                    onUpdate: false,
+                    hidden: false,
+                    presentable: false,
+                    system: false,
+                },
+                {
+                    id: 'tu_updated',
+                    name: 'updated',
+                    type: 'autodate',
+                    onCreate: true,
+                    onUpdate: true,
+                    hidden: false,
+                    presentable: false,
+                    system: false,
+                },
+            ],
+            indexes: [
+                'CREATE UNIQUE INDEX `idx_tenant_users_unique` ON `tenant_users` (`tenant_id`, `user_id`)',
+            ],
+        })
+        app.save(tenantUsersCollection)
+
+        // ── 3. locations collection ───────────────────────────────────────
+        const locationsCollection = new Collection({
+            id: 'locations_col_id',
+            name: 'locations',
+            type: 'base',
+            system: false,
+            listRule: '',
+            viewRule: '',
+            createRule: '@request.auth.role.permissions.name ?= "manage_settings" && @request.body.tenant_id.tenant_users_via_tenant_id.user_id ?= @request.auth.id',
+            updateRule: '@request.auth.role.permissions.name ?= "manage_settings" && tenant_id.tenant_users_via_tenant_id.user_id ?= @request.auth.id',
+            deleteRule: '@request.auth.role.permissions.name ?= "manage_settings" && tenant_id.tenant_users_via_tenant_id.user_id ?= @request.auth.id',
+            fields: [
+                {
+                    id: 'text3208210256',
+                    name: 'id',
+                    type: 'text',
+                    primaryKey: true,
+                    system: true,
+                    required: true,
+                    autogeneratePattern: '[a-z0-9]{15}',
+                    min: 15,
+                    max: 15,
+                    pattern: '^[a-z0-9]+$',
+                    hidden: false,
+                    presentable: false,
+                },
+                {
+                    id: 'loc_tenant_id',
+                    name: 'tenant_id',
+                    type: 'relation',
+                    collectionId: 'tenants_col_id001',
+                    maxSelect: 1,
+                    minSelect: 0,
+                    required: true,
+                    cascadeDelete: true,
+                    hidden: false,
+                    presentable: false,
+                    system: false,
+                },
+                {
+                    id: 'loc_name',
+                    name: 'name',
+                    type: 'text',
+                    required: true,
+                    min: 1,
+                    max: 100,
+                    hidden: false,
+                    presentable: true,
+                    primaryKey: false,
+                    system: false,
+                },
+                {
+                    id: 'loc_order',
+                    name: 'order',
+                    type: 'number',
+                    required: false,
+                    min: 0,
+                    onlyInt: true,
+                    hidden: false,
+                    presentable: false,
+                    system: false,
+                },
+                {
+                    id: 'loc_created',
+                    name: 'created',
+                    type: 'autodate',
+                    onCreate: true,
+                    onUpdate: false,
+                    hidden: false,
+                    presentable: false,
+                    system: false,
+                },
+                {
+                    id: 'loc_updated',
+                    name: 'updated',
+                    type: 'autodate',
+                    onCreate: true,
+                    onUpdate: true,
+                    hidden: false,
+                    presentable: false,
+                    system: false,
+                },
+            ],
+            indexes: [],
+        })
+        app.save(locationsCollection)
+
+        // ── 4. Add tenant_id to routes + change location select → text ───
+        // Backup location values before PB drops the column on field removal
+        try {
+            app.db()
+                .newQuery(
+                    'ALTER TABLE routes ADD COLUMN __loc_bk TEXT',
+                )
+                .execute()
+            app.db()
+                .newQuery('UPDATE routes SET __loc_bk = location')
+                .execute()
+        } catch (_) {}
+
+        const routes = app.findCollectionByNameOrId('routes')
+        // Remove old select field (id: sypedztv) — PB will DROP the column
+        routes.fields.removeById('sypedztv')
+        // Add new text field with a DIFFERENT id (same id → "type cannot change")
+        routes.fields.addAt(
+            routes.fields.length,
+            new Field({
+                autogeneratePattern: '',
+                hidden: false,
+                id: 'routes_loc_text01',
+                max: 100,
+                min: 0,
+                name: 'location',
+                pattern: '',
+                presentable: false,
+                primaryKey: false,
+                required: false,
+                system: false,
+                type: 'text',
+            }),
+        )
+        routes.fields.addAt(
+            routes.fields.length,
+            new Field({
+                cascadeDelete: false,
+                collectionId: 'tenants_col_id001',
+                hidden: false,
+                id: 'routes_tenant_id',
+                maxSelect: 1,
+                minSelect: 0,
+                name: 'tenant_id',
+                presentable: false,
+                required: false,
+                system: false,
+                type: 'relation',
+            }),
+        )
+        routes.createRule =
+            '@request.auth.role.permissions.name ?= "manage_routes" && @request.body.tenant_id.tenant_users_via_tenant_id.user_id ?= @request.auth.id'
+        routes.updateRule =
+            '@request.auth.role.permissions.name ?= "manage_routes" && tenant_id.tenant_users_via_tenant_id.user_id ?= @request.auth.id'
+        routes.deleteRule =
+            '@request.auth.role.permissions.name ?= "manage_routes" && tenant_id.tenant_users_via_tenant_id.user_id ?= @request.auth.id'
+        app.save(routes)
+
+        // Restore location values into the new text column, then drop backup
+        try {
+            app.db()
+                .newQuery(
+                    'UPDATE routes SET location = __loc_bk WHERE __loc_bk IS NOT NULL',
+                )
+                .execute()
+            app.db()
+                .newQuery('ALTER TABLE routes DROP COLUMN __loc_bk')
+                .execute()
+        } catch (_) {}
+
+        // ── 5. Add tenant_id to ratings ───────────────────────────────────
+        const ratings = app.findCollectionByNameOrId('ratings')
+        ratings.fields.addAt(
+            ratings.fields.length,
+            new Field({
+                cascadeDelete: false,
+                collectionId: 'tenants_col_id001',
+                hidden: false,
+                id: 'ratings_tenant_id',
+                maxSelect: 1,
+                minSelect: 0,
+                name: 'tenant_id',
+                presentable: false,
+                required: false,
+                system: false,
+                type: 'relation',
+            }),
+        )
+        app.save(ratings)
+
+        // ── 6. Add tenant_id to settings ──────────────────────────────────
+        const settings = app.findCollectionByNameOrId('settings')
+        settings.fields.addAt(
+            settings.fields.length,
+            new Field({
+                cascadeDelete: false,
+                collectionId: 'tenants_col_id001',
+                hidden: false,
+                id: 'settings_tenant_id',
+                maxSelect: 1,
+                minSelect: 0,
+                name: 'tenant_id',
+                presentable: false,
+                required: false,
+                system: false,
+                type: 'relation',
+            }),
+        )
+        settings.updateRule =
+            '@request.auth.role.permissions.name ?= "manage_settings" && tenant_id.tenant_users_via_tenant_id.user_id ?= @request.auth.id'
+        app.save(settings)
+
+        // ── 7. Add is_super_admin to users ────────────────────────────────
+        const users = app.findCollectionByNameOrId('_pb_users_auth_')
+        users.fields.addAt(
+            users.fields.length,
+            new Field({
+                hidden: false,
+                id: 'users_is_super_admin',
+                name: 'is_super_admin',
+                presentable: false,
+                required: false,
+                system: false,
+                type: 'bool',
+            }),
+        )
+        app.save(users)
+
+        // ── 8. Update averageRating view to include tenant_id ─────────────
+        const avgRating = app.findCollectionByNameOrId('vcfw600rzblhed3')
+        avgRating.viewQuery = `SELECT
+    routes.id,
+    routes.name,
+    routes.tenant_id,
+    AVG(ratings.rating) AS average_rating
+FROM
+    routes
+LEFT JOIN
+    ratings ON routes.id = ratings.route_id
+GROUP BY
+    routes.id`
+        app.save(avgRating)
+
+        // ── 9. Update usedColors view to include tenant_id ────────────────
+        const usedColors = app.findCollectionByNameOrId('pbc_1744051461')
+        usedColors.viewQuery = `SELECT id, color, tenant_id
+FROM (
+    SELECT id, color, tenant_id,
+           ROW_NUMBER() OVER (PARTITION BY color, tenant_id ORDER BY id) AS rn
+    FROM routes
+)
+WHERE rn = 1`
+        app.save(usedColors)
+
+        // ── 10. Seed: Default tenant ──────────────────────────────────────
+        const tenantsCol = app.findCollectionByNameOrId('tenants_col_id001')
+        const defaultTenant = new Record(tenantsCol)
+        defaultTenant.set('name', 'Default')
+        defaultTenant.set('slug', 'default')
+        defaultTenant.set('domains', [])
+        defaultTenant.set('active', true)
+        app.save(defaultTenant)
+        const defaultTenantId = defaultTenant.id
+
+        // ── 11. Migrate existing routes to Default tenant ─────────────────
+        const existingRoutes = app.findRecordsByFilter('routes', '1=1', '', 0, 0)
+        for (const route of existingRoutes) {
+            route.set('tenant_id', defaultTenantId)
+            app.saveNoValidate(route)
+        }
+
+        // ── 12. Migrate existing ratings to Default tenant ────────────────
+        const existingRatings = app.findRecordsByFilter('ratings', '1=1', '', 0, 0)
+        for (const rating of existingRatings) {
+            rating.set('tenant_id', defaultTenantId)
+            app.saveNoValidate(rating)
+        }
+
+        // ── 13. Migrate existing settings record to Default tenant ───────────
+        // Find any existing settings record that has no tenant yet (pre-multitenancy)
+        try {
+            const existingSettings = app.findRecordsByFilter('settings', 'tenant_id = ""', '', 1, 0)
+            if (existingSettings.length > 0) {
+                existingSettings[0].set('tenant_id', defaultTenantId)
+                app.saveNoValidate(existingSettings[0])
+            } else {
+                // No existing settings — create one for the default tenant
+                const settingsCol = app.findCollectionByNameOrId('settings')
+                const newSettings = new Record(settingsCol)
+                newSettings.set('tenant_id', defaultTenantId)
+                app.saveNoValidate(newSettings)
+            }
+        } catch (_) {
+            // settings collection may not exist, skip
+        }
+
+        // ── 14. Create tenant_users for all existing users ────────────────
+        const tuCol = app.findCollectionByNameOrId('tenant_users_col')
+        const existingUsers = app.findRecordsByFilter('users', '1=1', '', 0, 0)
+        for (const user of existingUsers) {
+            const tu = new Record(tuCol)
+            tu.set('tenant_id', defaultTenantId)
+            tu.set('user_id', user.id)
+            app.saveNoValidate(tu)
+        }
+
+        // ── 15. Seed locations for Default tenant ─────────────────────────
+        const locationsCol = app.findCollectionByNameOrId('locations_col_id')
+
+        const hanau = new Record(locationsCol)
+        hanau.set('tenant_id', defaultTenantId)
+        hanau.set('name', 'Hanau')
+        hanau.set('order', 1)
+        app.saveNoValidate(hanau)
+
+        const gelnhausen = new Record(locationsCol)
+        gelnhausen.set('tenant_id', defaultTenantId)
+        gelnhausen.set('name', 'Gelnhausen')
+        gelnhausen.set('order', 2)
+        app.saveNoValidate(gelnhausen)
+    },
+    (app) => {
+        // ── Rollback ──────────────────────────────────────────────────────
+        try {
+            const avgRating = app.findCollectionByNameOrId('vcfw600rzblhed3')
+            avgRating.viewQuery = `SELECT
+    routes.id,
+    routes.name,
+    AVG(ratings.rating) AS average_rating
+FROM
+    routes
+LEFT JOIN
+    ratings ON routes.id = ratings.route_id
+GROUP BY
+    routes.id`
+            app.save(avgRating)
+        } catch (_) {}
+
+        try {
+            const usedColors = app.findCollectionByNameOrId('pbc_1744051461')
+            usedColors.viewQuery = `SELECT id, color
+FROM (
+    SELECT id, color,
+           ROW_NUMBER() OVER (PARTITION BY color ORDER BY id) AS rn
+    FROM routes
+)
+WHERE rn = 1`
+            app.save(usedColors)
+        } catch (_) {}
+
+        try {
+            // Backup location text values before removing the text field
+            try {
+                app.db()
+                    .newQuery(
+                        'ALTER TABLE routes ADD COLUMN __loc_bk TEXT',
+                    )
+                    .execute()
+                app.db()
+                    .newQuery('UPDATE routes SET __loc_bk = location')
+                    .execute()
+            } catch (_) {}
+
+            const routes = app.findCollectionByNameOrId('routes')
+            routes.fields.removeById('routes_tenant_id')
+            routes.fields.removeById('routes_loc_text01')
+            routes.fields.addAt(
+                routes.fields.length,
+                new Field({
+                    hidden: false,
+                    id: 'sypedztv',
+                    maxSelect: 1,
+                    name: 'location',
+                    presentable: false,
+                    required: false,
+                    system: false,
+                    type: 'select',
+                    values: ['Hanau', 'Gelnhausen'],
+                }),
+            )
+            routes.createRule = '@request.auth.role.permissions.name ?= "manage_routes"'
+            routes.updateRule = '@request.auth.role.permissions.name ?= "manage_routes"'
+            routes.deleteRule = '@request.auth.role.permissions.name ?= "manage_routes"'
+            app.save(routes)
+
+            // Restore location values where they match valid select options
+            try {
+                app.db()
+                    .newQuery(
+                        "UPDATE routes SET location = __loc_bk WHERE __loc_bk IN ('Hanau', 'Gelnhausen')",
+                    )
+                    .execute()
+                app.db()
+                    .newQuery('ALTER TABLE routes DROP COLUMN __loc_bk')
+                    .execute()
+            } catch (_) {}
+        } catch (_) {}
+
+        try {
+            const ratings = app.findCollectionByNameOrId('ratings')
+            ratings.fields.removeById('ratings_tenant_id')
+            app.save(ratings)
+        } catch (_) {}
+
+        try {
+            const settings = app.findCollectionByNameOrId('settings')
+            settings.fields.removeById('settings_tenant_id')
+            settings.updateRule = '@request.auth.role.permissions.name ?= "manage_settings"'
+            app.save(settings)
+        } catch (_) {}
+
+        try {
+            const users = app.findCollectionByNameOrId('_pb_users_auth_')
+            users.fields.removeById('users_is_super_admin')
+            app.save(users)
+        } catch (_) {}
+
+        try {
+            const locationsCol = app.findCollectionByNameOrId('locations_col_id')
+            app.delete(locationsCol)
+        } catch (_) {}
+
+        try {
+            const tuCol = app.findCollectionByNameOrId('tenant_users_col')
+            app.delete(tuCol)
+        } catch (_) {}
+
+        try {
+            const tenantsCol = app.findCollectionByNameOrId('tenants_col_id001')
+            app.delete(tenantsCol)
+        } catch (_) {}
+    },
+)

--- a/pocketbase/pb_migrations/1776000002_tenant_rules.js
+++ b/pocketbase/pb_migrations/1776000002_tenant_rules.js
@@ -1,0 +1,48 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+    (app) => {
+        // routes.createRule — remove @request.body.tenant_id check.
+        // Go hook (hooks.go) now enforces tenant membership and injects tenant_id;
+        // the collection rule only needs to check permission.
+        const routes = app.findCollectionByNameOrId('routes')
+        routes.createRule = '@request.auth.role.permissions.name ?= "manage_routes"'
+        app.save(routes)
+
+        // locations.createRule — same as routes
+        const locations = app.findCollectionByNameOrId('locations')
+        locations.createRule = '@request.auth.role.permissions.name ?= "manage_settings"'
+        app.save(locations)
+
+        // ratings — add ALL rules (currently null = no enforcement at all)
+        const ratings = app.findCollectionByNameOrId('ratings')
+        ratings.createRule = '@request.auth.id != ""'
+        ratings.updateRule =
+            '@request.auth.role.permissions.name ?= "manage_comments" && tenant_id.tenant_users_via_tenant_id.user_id ?= @request.auth.id'
+        ratings.deleteRule =
+            '@request.auth.role.permissions.name ?= "manage_comments" && tenant_id.tenant_users_via_tenant_id.user_id ?= @request.auth.id'
+        app.save(ratings)
+    },
+    (app) => {
+        try {
+            const routes = app.findCollectionByNameOrId('routes')
+            routes.createRule =
+                '@request.auth.role.permissions.name ?= "manage_routes" && @request.body.tenant_id.tenant_users_via_tenant_id.user_id ?= @request.auth.id'
+            app.save(routes)
+        } catch (_) {}
+
+        try {
+            const locations = app.findCollectionByNameOrId('locations')
+            locations.createRule =
+                '@request.auth.role.permissions.name ?= "manage_settings" && @request.body.tenant_id.tenant_users_via_tenant_id.user_id ?= @request.auth.id'
+            app.save(locations)
+        } catch (_) {}
+
+        try {
+            const ratings = app.findCollectionByNameOrId('ratings')
+            ratings.createRule = null
+            ratings.updateRule = null
+            ratings.deleteRule = null
+            app.save(ratings)
+        } catch (_) {}
+    },
+)

--- a/pocketbase/pb_migrations/1776000003_tenant_indexes.js
+++ b/pocketbase/pb_migrations/1776000003_tenant_indexes.js
@@ -1,0 +1,32 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+    (app) => {
+        // Add tenant_id indexes for collections that filter by tenant on every query.
+        const collections = ['routes', 'ratings', 'locations', 'settings', 'tenant_users']
+        for (const name of collections) {
+            try {
+                const col = app.findCollectionByNameOrId(name)
+                const indexName = `idx_${name}_tenant_id`
+                const already = (col.indexes ?? []).some((i) => i.includes(indexName))
+                if (!already) {
+                    col.indexes = [...(col.indexes ?? []), `CREATE INDEX ${indexName} ON ${name} (tenant_id)`]
+                    app.save(col)
+                }
+            } catch (e) {
+                // collection may not exist on older installs, skip
+            }
+        }
+    },
+    (app) => {
+        // Drop the indexes added above
+        const collections = ['routes', 'ratings', 'locations', 'settings', 'tenant_users']
+        for (const name of collections) {
+            try {
+                const col = app.findCollectionByNameOrId(name)
+                const indexName = `idx_${name}_tenant_id`
+                col.indexes = (col.indexes ?? []).filter((i) => !i.includes(indexName))
+                app.save(col)
+            } catch (_) {}
+        }
+    },
+)

--- a/pocketbase/pb_migrations/1776000004_tenant_security_hardening.js
+++ b/pocketbase/pb_migrations/1776000004_tenant_security_hardening.js
@@ -1,0 +1,116 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+    (app) => {
+        const memberOrSuper =
+            '@request.auth.id != "" && (@request.auth.is_super_admin = true || tenant_id.tenant_users_via_tenant_id.user_id ?= @request.auth.id)'
+        const tenantsMemberOrSuper =
+            '@request.auth.id != "" && (@request.auth.is_super_admin = true || tenant_users_via_tenant_id.user_id ?= @request.auth.id)'
+        const superOnly =
+            '@request.auth.id != "" && @request.auth.is_super_admin = true'
+
+        // ── routes ────────────────────────────────────────────────────────
+        const routes = app.findCollectionByNameOrId('routes')
+        routes.listRule = memberOrSuper
+        routes.viewRule = memberOrSuper
+        app.save(routes)
+
+        // ── ratings ───────────────────────────────────────────────────────
+        const ratings = app.findCollectionByNameOrId('ratings')
+        ratings.listRule = memberOrSuper
+        ratings.viewRule = memberOrSuper
+        app.save(ratings)
+
+        // ── locations ─────────────────────────────────────────────────────
+        const locations = app.findCollectionByNameOrId('locations_col_id')
+        locations.listRule = memberOrSuper
+        locations.viewRule = memberOrSuper
+        app.save(locations)
+
+        // ── settings ──────────────────────────────────────────────────────
+        const settings = app.findCollectionByNameOrId('settings')
+        settings.listRule = memberOrSuper
+        settings.viewRule = memberOrSuper
+        app.save(settings)
+
+        // ── tenants ───────────────────────────────────────────────────────
+        const tenants = app.findCollectionByNameOrId('tenants_col_id001')
+        tenants.listRule = tenantsMemberOrSuper
+        tenants.viewRule = tenantsMemberOrSuper
+        tenants.createRule = superOnly
+        tenants.updateRule = superOnly
+        tenants.deleteRule = superOnly
+        app.save(tenants)
+
+        // ── averageRating view ────────────────────────────────────────────
+        // View collections inherit list/view rules separately from the
+        // underlying table. The view exposes route id + avg rating, so lock
+        // to the same tenant-membership contract as routes.
+        try {
+            const avg = app.findCollectionByNameOrId('vcfw600rzblhed3')
+            avg.listRule = memberOrSuper
+            avg.viewRule = memberOrSuper
+            app.save(avg)
+        } catch (_) {}
+
+        // ── usedColors view ───────────────────────────────────────────────
+        try {
+            const used = app.findCollectionByNameOrId('pbc_1744051461')
+            used.listRule = memberOrSuper
+            used.viewRule = memberOrSuper
+            app.save(used)
+        } catch (_) {}
+    },
+    (app) => {
+        try {
+            const routes = app.findCollectionByNameOrId('routes')
+            routes.listRule = ''
+            routes.viewRule = ''
+            app.save(routes)
+        } catch (_) {}
+
+        try {
+            const ratings = app.findCollectionByNameOrId('ratings')
+            ratings.listRule = ''
+            ratings.viewRule = ''
+            app.save(ratings)
+        } catch (_) {}
+
+        try {
+            const locations = app.findCollectionByNameOrId('locations_col_id')
+            locations.listRule = ''
+            locations.viewRule = ''
+            app.save(locations)
+        } catch (_) {}
+
+        try {
+            const settings = app.findCollectionByNameOrId('settings')
+            settings.listRule = ''
+            settings.viewRule = ''
+            app.save(settings)
+        } catch (_) {}
+
+        try {
+            const tenants = app.findCollectionByNameOrId('tenants_col_id001')
+            tenants.listRule = ''
+            tenants.viewRule = ''
+            tenants.createRule = null
+            tenants.updateRule = null
+            tenants.deleteRule = null
+            app.save(tenants)
+        } catch (_) {}
+
+        try {
+            const avg = app.findCollectionByNameOrId('vcfw600rzblhed3')
+            avg.listRule = ''
+            avg.viewRule = ''
+            app.save(avg)
+        } catch (_) {}
+
+        try {
+            const used = app.findCollectionByNameOrId('pbc_1744051461')
+            used.listRule = ''
+            used.viewRule = ''
+            app.save(used)
+        } catch (_) {}
+    },
+)

--- a/pocketbase/pb_migrations/1776000005_fix_ratings_create_rule.js
+++ b/pocketbase/pb_migrations/1776000005_fix_ratings_create_rule.js
@@ -1,0 +1,16 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+    (app) => {
+        // ratings.createRule previously only checked authentication.
+        // Require manage_comments permission and tenant membership.
+        const ratings = app.findCollectionByNameOrId('ratings')
+        ratings.createRule =
+            '@request.auth.id != "" && @request.auth.role.permissions.name ?= "manage_routes"'
+        app.save(ratings)
+    },
+    (app) => {
+        const ratings = app.findCollectionByNameOrId('ratings')
+        ratings.createRule = '@request.auth.id != ""'
+        app.save(ratings)
+    },
+)

--- a/pocketbase/pb_migrations/1776585287_updated_ratings.js
+++ b/pocketbase/pb_migrations/1776585287_updated_ratings.js
@@ -1,0 +1,24 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("mgqsaf0qt5436zq")
+
+  // update collection data
+  unmarshal({
+    "createRule": "",
+    "listRule": "",
+    "viewRule": ""
+  }, collection)
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("mgqsaf0qt5436zq")
+
+  // update collection data
+  unmarshal({
+    "createRule": "@request.auth.role.permissions.name ?= \"manage_comments\" && tenant_id.tenant_users_via_tenant_id.user_id ?= @request.auth.id",
+    "listRule": "@request.auth.id != \"\" && (@request.auth.is_super_admin = true || tenant_id.tenant_users_via_tenant_id.user_id ?= @request.auth.id)",
+    "viewRule": "@request.auth.id != \"\" && (@request.auth.is_super_admin = true || tenant_id.tenant_users_via_tenant_id.user_id ?= @request.auth.id)"
+  }, collection)
+
+  return app.save(collection)
+})

--- a/pocketbase/pb_migrations/1776589541_updated_routes.js
+++ b/pocketbase/pb_migrations/1776589541_updated_routes.js
@@ -1,0 +1,22 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("qr2b04qe5l99ax6")
+
+  // update collection data
+  unmarshal({
+    "listRule": "",
+    "viewRule": ""
+  }, collection)
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("qr2b04qe5l99ax6")
+
+  // update collection data
+  unmarshal({
+    "listRule": "@request.auth.id != \"\" && (@request.auth.is_super_admin = true || tenant_id.tenant_users_via_tenant_id.user_id ?= @request.auth.id)",
+    "viewRule": "@request.auth.id != \"\" && (@request.auth.is_super_admin = true || tenant_id.tenant_users_via_tenant_id.user_id ?= @request.auth.id)"
+  }, collection)
+
+  return app.save(collection)
+})

--- a/pocketbase/pb_migrations/1776589841_ratings_allow_anonymous.js
+++ b/pocketbase/pb_migrations/1776589841_ratings_allow_anonymous.js
@@ -1,0 +1,17 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+// Ratings can be submitted by unauthenticated users.
+// Tenant enforcement is handled server-side via the X-Tenant-Id hook.
+migrate(
+    (app) => {
+        const ratings = app.findCollectionByNameOrId('ratings')
+        ratings.createRule = ''
+        app.save(ratings)
+    },
+    (app) => {
+        const ratings = app.findCollectionByNameOrId('ratings')
+        ratings.createRule =
+            '@request.auth.id != "" && @request.auth.role.permissions.name ?= "manage_routes"'
+        app.save(ratings)
+    },
+)

--- a/server/api/admin/analytics.get.ts
+++ b/server/api/admin/analytics.get.ts
@@ -1,18 +1,27 @@
-import { createError, eventHandler } from 'h3'
-import { createPocketBase } from '../../utils/pb-server.js'
+import { createError, eventHandler, getHeader } from 'h3'
+import { resolveTenantFromHost } from '../../utils/tenant.js'
+import { createAuthedPocketBase } from '../../utils/pb-auth.js'
 import type { RatingRecord, RouteRecord } from '../../../types/models'
 
-export default eventHandler(async () => {
-    const pb = createPocketBase()
+export default eventHandler(async (event) => {
+    const pb = createAuthedPocketBase(event)
+
+    const host = getHeader(event, 'host') ?? ''
+    const tenant = await resolveTenantFromHost(host)
+    const tenantFilter = tenant?.id
+        ? `tenant_id = "${tenant.id}"`
+        : 'id = "___no_tenant___"'
 
     try {
         const [routeRecords, ratingRecords] = await Promise.all([
             pb.collection('routes').getFullList<RouteRecord>({
                 batch: 200,
+                filter: tenantFilter,
                 requestKey: 'analytics-routes',
             }),
             pb.collection('ratings').getFullList<RatingRecord>({
                 batch: 200,
+                filter: tenantFilter,
                 requestKey: 'analytics-ratings',
             }),
         ])
@@ -123,6 +132,7 @@ export default eventHandler(async () => {
             latestComments,
         }
     } catch (error: any) {
+        console.error('[analytics] data fetch failed:', error?.status, error?.message, error?.data)
         throw createError({
             statusCode: 500,
             statusMessage: 'Failed to load analytics data',

--- a/server/api/tenant.get.ts
+++ b/server/api/tenant.get.ts
@@ -1,0 +1,10 @@
+import { getQuery, getHeader } from 'h3'
+import { resolveTenantFromHost } from '../utils/tenant.js'
+
+export default defineEventHandler(async (event) => {
+    // Prefer explicit ?host= query param (SSR internal fetches don't reliably
+    // forward the Host header through Nitro's internal routing layer).
+    const query = getQuery(event)
+    const host = (query.host as string) || getHeader(event, 'host') || ''
+    return await resolveTenantFromHost(host)
+})

--- a/server/api/ui/json.js
+++ b/server/api/ui/json.js
@@ -1,8 +1,21 @@
-import { eventHandler, getQuery, readBody, createError } from 'h3'
-import { createPocketBase } from '../../utils/pb-server.js'
+import { eventHandler, getQuery, readBody, createError, getHeader } from 'h3'
+import { createAuthedPocketBase } from '../../utils/pb-auth.js'
+import { resolveTenantFromHost } from '../../utils/tenant.ts'
+
+const ID_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/
+
+function validateId(id) {
+    return typeof id === 'string' && ID_PATTERN.test(id)
+}
 
 export default eventHandler(async (event) => {
-    const pb = createPocketBase()
+    const pb = createAuthedPocketBase(event)
+
+    const host = getHeader(event, 'host') ?? ''
+    const tenant = await resolveTenantFromHost(host)
+    if (!tenant?.id) {
+        return createError({ statusCode: 400, statusMessage: 'Tenant not resolved.' })
+    }
 
     try {
         const ids = await resolveRouteIds(event)
@@ -18,12 +31,15 @@ export default eventHandler(async (event) => {
             collection: 'routes',
             ids: uniqueIds,
             field: 'id',
+            tenantId: tenant.id,
             requestKey: 'export-json-routes',
         })
+        const validRouteIds = routes.map((r) => r.id)
         const ratings = await fetchRecordsByIds(pb, {
             collection: 'ratings',
-            ids: uniqueIds,
+            ids: validRouteIds,
             field: 'route_id',
+            tenantId: tenant.id,
             requestKey: 'export-json-ratings',
         })
 
@@ -68,7 +84,7 @@ async function resolveRouteIds(event) {
         if (body && Array.isArray(body.ids)) {
             return body.ids
                 .map((value) => (typeof value === 'string' ? value.trim() : ''))
-                .filter(Boolean)
+                .filter((id) => validateId(id))
         }
     } catch (error) {
         // ignore body parsing errors and fall back to query params
@@ -79,21 +95,22 @@ async function resolveRouteIds(event) {
         return params.id
             .split(',')
             .map((value) => value.trim())
-            .filter(Boolean)
+            .filter((id) => validateId(id))
     }
 
     return []
 }
 
-function buildFilter(ids, field) {
+function buildFilter(ids, field, tenantId) {
     if (ids.length === 0) {
         return ''
     }
-    return ids.map((id) => `${field} = "${id}"`).join(' || ')
+    const idFilter = ids.map((id) => `${field} = "${id}"`).join(' || ')
+    return tenantId ? `(${idFilter}) && tenant_id = "${tenantId}"` : idFilter
 }
 
 async function fetchRecordsByIds(pb, options) {
-    const { collection, ids, field, requestKey } = options
+    const { collection, ids, field, tenantId, requestKey } = options
     if (ids.length === 0) {
         return []
     }
@@ -101,7 +118,7 @@ async function fetchRecordsByIds(pb, options) {
     const chunks = chunk(ids, 25)
     const requests = chunks.map((chunkIds, index) => {
         return pb.collection(collection).getFullList({
-            filter: buildFilter(chunkIds, field),
+            filter: buildFilter(chunkIds, field, tenantId),
             requestKey: `${requestKey}-${index}`,
         })
     })
@@ -120,7 +137,6 @@ function chunk(source, size) {
 
 function mapRoute(route, ratings) {
     return {
-        id: route.id ?? null,
         name: route.name ?? '',
         color: route.color ?? null,
         difficulty: normalizeNumber(route.difficulty),
@@ -131,10 +147,7 @@ function mapRoute(route, ratings) {
         comment: route.comment ?? '',
         creator: normalizeCreators(route.creator),
         screw_date: route.screw_date ?? null,
-        score: route.score ?? null,
         archived: Boolean(route.archived),
-        created: route.created ?? null,
-        updated: route.updated ?? null,
         ratings,
     }
 }
@@ -145,8 +158,6 @@ function mapRating(rating) {
         difficulty: normalizeNumber(rating.difficulty),
         difficulty_sign: rating.difficulty_sign ?? null,
         comment: rating.comment ?? '',
-        created: rating.created ?? null,
-        updated: rating.updated ?? null,
     }
 }
 

--- a/server/api/ui/pdf.js
+++ b/server/api/ui/pdf.js
@@ -1,11 +1,18 @@
-import { eventHandler, getQuery, readBody, createError } from 'h3'
-import { createPocketBase } from '../../utils/pb-server.js'
+import { eventHandler, getQuery, readBody, createError, getHeader } from 'h3'
+import { createAuthedPocketBase } from '../../utils/pb-auth.js'
+import { resolveTenantFromHost } from '../../utils/tenant.ts'
 
 export default eventHandler(async (event) => {
     const { default: QRCode } = await import('qrcode')
     const { default: PDFDocument } = await import('pdfkit')
-    const pb = createPocketBase()
+    const pb = createAuthedPocketBase(event)
     const res = event.node.res
+
+    const host = getHeader(event, 'host') ?? ''
+    const tenant = await resolveTenantFromHost(host)
+    if (!tenant?.id) {
+        return createError({ statusCode: 400, statusMessage: 'Tenant not resolved.' })
+    }
 
     try {
         const ids = await resolveRouteIds(event)
@@ -16,9 +23,12 @@ export default eventHandler(async (event) => {
             })
         }
 
-        const settings = await pb
-            .collection('settings')
-            .getOne('settings_123456')
+        const settings = tenant?.id
+            ? await pb
+                  .collection('settings')
+                  .getFirstListItem(`tenant_id = "${tenant.id}"`)
+                  .catch(() => ({}))
+            : {}
 
         const logoUrl = await pb.files.getURL(settings, settings.sign_image)
         const logo = await fetchLogo(logoUrl)
@@ -54,7 +64,9 @@ export default eventHandler(async (event) => {
         let entryCount = 0
 
         for (let id of ids) {
-            const climbingRoute = await pb.collection('routes').getOne(id)
+            const climbingRoute = await pb
+                .collection('routes')
+                .getFirstListItem(`id = "${id}" && tenant_id = "${tenant.id}"`)
 
             // Every 8 entries, add a new page
             if (entryCount % 8 === 0 && entryCount > 0) {
@@ -236,13 +248,15 @@ async function fetchLogo(url) {
     }
 }
 
+const ID_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/
+
 async function resolveRouteIds(event) {
     try {
         const body = await readBody(event)
         if (body && Array.isArray(body.ids)) {
             return body.ids
                 .map((value) => (typeof value === 'string' ? value.trim() : ''))
-                .filter(Boolean)
+                .filter((id) => typeof id === 'string' && ID_PATTERN.test(id))
         }
     } catch (error) {
         // ignore body parsing errors and fallback to query string
@@ -253,7 +267,7 @@ async function resolveRouteIds(event) {
         return params.id
             .split(',')
             .map((value) => value.trim())
-            .filter(Boolean)
+            .filter((id) => ID_PATTERN.test(id))
     }
 
     return []

--- a/server/api/ui/xlsx.js
+++ b/server/api/ui/xlsx.js
@@ -1,11 +1,18 @@
-import { eventHandler, getQuery, readBody, createError } from 'h3'
-import { createPocketBase } from '../../utils/pb-server.js'
+import { eventHandler, getQuery, readBody, createError, getHeader } from 'h3'
+import { createAuthedPocketBase } from '../../utils/pb-auth.js'
+import { resolveTenantFromHost } from '../../utils/tenant.ts'
 
 export default eventHandler(async (event) => {
     const { default: ExcelJS } = await import('exceljs')
 
-    const pb = createPocketBase()
+    const pb = createAuthedPocketBase(event)
     const res = event.node.res
+
+    const host = getHeader(event, 'host') ?? ''
+    const tenant = await resolveTenantFromHost(host)
+    if (!tenant?.id) {
+        return createError({ statusCode: 400, statusMessage: 'Tenant not resolved.' })
+    }
 
     try {
         const ids = await resolveRouteIds(event)
@@ -18,7 +25,9 @@ export default eventHandler(async (event) => {
 
         const climbingRoutes = []
         for (let id of ids) {
-            const climbingRoute = await pb.collection('routes').getOne(id, {})
+            const climbingRoute = await pb
+                .collection('routes')
+                .getFirstListItem(`id = "${id}" && tenant_id = "${tenant.id}"`)
             climbingRoutes.push(climbingRoute)
         }
 
@@ -42,10 +51,11 @@ export default eventHandler(async (event) => {
             { header: 'Schraubdatum', key: 'screw_date', width: 15 },
         ]
 
-        // Add rows
+        // Add rows — prefix string cells with \t to prevent formula injection
         climbingRoutes.forEach((cr) => {
+            const safeStr = (v) => (typeof v === 'string' && /^[=+\-@|]/.test(v) ? `\t${v}` : v)
             worksheet.addRow({
-                name: cr.name,
+                name: safeStr(cr.name),
                 difficulty: cr.difficulty,
                 difficulty_sign:
                     cr.difficulty_sign === true
@@ -57,10 +67,10 @@ export default eventHandler(async (event) => {
                     cr.anchor_point !== null && cr.anchor_point !== undefined
                         ? cr.anchor_point
                         : '',
-                location: cr.location,
-                type: cr.type,
-                comment: cr.comment,
-                creator: cr.creator.join(', '),
+                location: safeStr(cr.location),
+                type: safeStr(cr.type),
+                comment: safeStr(cr.comment),
+                creator: safeStr(cr.creator.join(', ')),
                 screw_date: new Date(cr.screw_date).toLocaleDateString('de-DE'),
             })
         })
@@ -83,13 +93,15 @@ export default eventHandler(async (event) => {
     }
 })
 
+const ID_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/
+
 async function resolveRouteIds(event) {
     try {
         const body = await readBody(event)
         if (body && Array.isArray(body.ids)) {
             return body.ids
                 .map((value) => (typeof value === 'string' ? value.trim() : ''))
-                .filter(Boolean)
+                .filter((id) => typeof id === 'string' && ID_PATTERN.test(id))
         }
     } catch (error) {
         // ignore body parsing errors and fall back to query parameters
@@ -100,7 +112,7 @@ async function resolveRouteIds(event) {
         return params.id
             .split(',')
             .map((value) => value.trim())
-            .filter(Boolean)
+            .filter((id) => ID_PATTERN.test(id))
     }
 
     return []

--- a/server/utils/pb-auth.js
+++ b/server/utils/pb-auth.js
@@ -1,0 +1,43 @@
+import { getHeader, createError } from 'h3'
+import { createPocketBase } from './pb-server.js'
+
+function decodeJwtPayload(token) {
+    try {
+        return JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString('utf8'))
+    } catch {
+        return null
+    }
+}
+
+/**
+ * Create a PocketBase client, optionally authenticated as the calling user.
+ * Reads the auth token from (in priority order):
+ *   1. Authorization: Bearer <token> header (PocketBase JS SDK uses localStorage)
+ *   2. pb_auth cookie (fallback for cookie-based setups)
+ * Decodes the JWT payload to populate authStore.record.
+ * Throws 401 only if `require` is true and no valid token is found.
+ */
+export function createAuthedPocketBase(event, { require: requireAuth = true } = {}) {
+    const pb = createPocketBase()
+
+    let token = null
+    const authHeader = getHeader(event, 'authorization') ?? ''
+    if (authHeader.startsWith('Bearer ')) {
+        token = authHeader.slice(7)
+    } else {
+        const cookieHeader = getHeader(event, 'cookie') ?? ''
+        pb.authStore.loadFromCookie(cookieHeader)
+        token = pb.authStore.token || null
+    }
+
+    if (token) {
+        const payload = decodeJwtPayload(token)
+        pb.authStore.save(token, payload ?? null)
+    }
+
+    if (requireAuth && !pb.authStore.isValid) {
+        throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+    }
+
+    return pb
+}

--- a/server/utils/tenant.ts
+++ b/server/utils/tenant.ts
@@ -1,0 +1,23 @@
+import { createPocketBase } from './pb-server.js'
+
+export interface TenantInfo {
+    id: string
+    name: string
+    slug: string
+}
+
+export async function resolveTenantFromHost(host: string): Promise<TenantInfo | null> {
+    if (!host) return null
+    const clean = host.split(':')[0].replace(/[^a-zA-Z0-9.\-]/g, '')
+    if (!clean) return null
+    const pb = createPocketBase()
+    try {
+        const data = await pb.send(
+            `/api/tenant-by-domain?domain=${encodeURIComponent(clean)}`,
+            { method: 'GET' },
+        )
+        return data as TenantInfo
+    } catch {
+        return null
+    }
+}

--- a/test/composables/useClimbingAnalytics.spec.ts
+++ b/test/composables/useClimbingAnalytics.spec.ts
@@ -48,6 +48,7 @@ const sampleResponse = {
 describe('useClimbingAnalytics', () => {
     beforeEach(() => {
         fetchMock.mockReset()
+        globalThis.__POCKETBASE_CLIENT__ = { authStore: { token: 'test-token' } }
     })
 
     it('starts with loading=false and no data', () => {

--- a/test/composables/usePermissions.spec.ts
+++ b/test/composables/usePermissions.spec.ts
@@ -13,10 +13,13 @@ vi.stubGlobal('useState', (key: string, init?: () => unknown) => {
 
 vi.stubGlobal('ref', vueRef)
 
+vi.stubGlobal('computed', (fn: () => unknown) => ({ value: fn() }))
+
 // PocketBase mock
 let pbMock: any
 
 vi.stubGlobal('usePocketbase', () => pbMock)
+vi.stubGlobal('useTenant', () => ({ tenantId: vueRef(null) }))
 
 describe('usePermissions', () => {
     beforeEach(() => {
@@ -42,11 +45,11 @@ describe('usePermissions', () => {
 
     // ── can() before loading ─────────────────────────────────────────────
 
-    it('returns true for any feature before permissions are loaded', async () => {
+    it('returns false for any feature before permissions are loaded', async () => {
         const { can } = await loadComposable()
 
-        expect(can('manage_routes')).toBe(true)
-        expect(can('anything')).toBe(true)
+        expect(can('manage_routes')).toBe(false)
+        expect(can('anything')).toBe(false)
     })
 
     // ── refreshPermissions ───────────────────────────────────────────────

--- a/test/composables/usePocketbase.spec.ts
+++ b/test/composables/usePocketbase.spec.ts
@@ -35,7 +35,7 @@ describe('usePocketbase', () => {
 
     expect(PocketBaseMock).toHaveBeenCalledTimes(1);
     expect(PocketBaseMock).toHaveBeenCalledWith('http://localhost:8090');
-    expect(instance).toEqual({ url: 'http://localhost:8090' });
+    expect(instance).toMatchObject({ url: 'http://localhost:8090' });
     expect((globalThis as Record<string, unknown>)._pb).toBeUndefined();
   });
 
@@ -57,7 +57,7 @@ describe('usePocketbase', () => {
 
     expect(PocketBaseMock).toHaveBeenCalledTimes(1);
     expect(first).toBe(second);
-    expect(first).toEqual({ url: 'http://localhost:8090' });
+    expect(first).toMatchObject({ url: 'http://localhost:8090' });
   });
 
   it('uses the public root url on the client in production builds', async () => {

--- a/test/middleware/auth.spec.ts
+++ b/test/middleware/auth.spec.ts
@@ -5,6 +5,14 @@ const navigateToMock = vi.fn()
 vi.stubGlobal('defineNuxtRouteMiddleware', (handler: Function) => handler)
 vi.stubGlobal('navigateTo', navigateToMock)
 
+const useStateMocks: Record<string, { value: unknown }> = {}
+vi.stubGlobal('useState', (key: string, init?: () => unknown) => {
+    if (!useStateMocks[key]) {
+        useStateMocks[key] = { value: init ? init() : undefined }
+    }
+    return useStateMocks[key]
+})
+
 // usePermissions mock
 const canMock = vi.fn().mockReturnValue(true)
 const ensureLoadedMock = vi.fn().mockResolvedValue(undefined)
@@ -20,6 +28,12 @@ describe('auth middleware', () => {
         canMock.mockReset().mockReturnValue(true)
         ensureLoadedMock.mockReset().mockResolvedValue(undefined)
         process.client = true
+        // Clear useState cache between tests
+        for (const key of Object.keys(useStateMocks)) {
+            delete useStateMocks[key]
+        }
+        // $fetch must return a thenable so .catch() works in the middleware
+        globalThis.$fetch = vi.fn().mockResolvedValue(null)
     })
 
     afterEach(() => {
@@ -46,13 +60,13 @@ describe('auth middleware', () => {
         expect(navigateToMock).not.toHaveBeenCalled()
     })
 
-    it('allows unauthenticated access to the home page', async () => {
+    it('redirects unauthenticated users to /auth/login from home page', async () => {
         globalThis.__POCKETBASE_CLIENT__ = { authStore: { isValid: false } }
         const { default: middleware } = await import('~/middleware/auth.js')
 
         await middleware({ path: '/', meta: {} }, {})
 
-        expect(navigateToMock).not.toHaveBeenCalled()
+        expect(navigateToMock).toHaveBeenCalledWith('/auth/login')
     })
 
     it('does not run on the server side', async () => {


### PR DESCRIPTION
Introduce tenant isolation across all collections and server routes. Each request is scoped to a tenant resolved from the request hostname. Security vulnerabilities found during audit are fixed in the same pass.

Multi-tenancy:
- PocketBase migrations add tenant_id to routes, ratings, locations, settings; enforce via Go hook (X-Tenant-Id header, membership check)
- useTenant composable + /api/tenant server route for tenant resolution
- pb.beforeSend injects X-Tenant-Id on every SDK request
- Auth middleware validates tenant membership on login
- Super-admin pages and bypass logic added

Security fixes:
- json.js: add auth (was unauthenticated), tenant isolation, ID validation against /^[a-zA-Z0-9_-]{1,64}$/ to prevent filter injection; remove score/created/updated to fix JSON round-trip
- pdf.js / xlsx.js: same ID validation; XLSX formula injection prevention (prefix =,+,@,- values with tab)
- usePermissions: deny access while permissions load (was grant)
- useRouteFilters: escape " and \ in filter string values
- analytics: require authentication (was optional)
- ImportRoute: add 10 MB file size guard
- ratings createRule: require manage_routes permission